### PR TITLE
CB-1322 - Fix for process control display not always loading correctly

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "angular-resource": "~1.5",
     "angular-mocks": "~1.5",
     "angular-ui-utils": "~0.1",
-    "angular-ui-router": "~0.2",
+    "angular-ui-router": "~0.3",
     "cryptojs": "*",
     "d3": "~3",
     "hammerjs": "~2.0.4",


### PR DESCRIPTION
updated angular-ui-router - the old version (~0.2) destroyed currentScope after creating the targetScope when routing between states, which caused our SensorService connection to get disconnected at the wrong time when switching between certain displays. 

For example - if you were on the observation detail display and used the side-nav to navigate to the process control display, the process control's scope would get created before the observation detail display's scope was destroyed. Causing a websocket disconnect/reconnect dance. Version ~0.3 fixes this. 

Yay for one-character-change bug fixes 👍 