### PR TITLE
First version of the utilisation reports

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -312,7 +312,11 @@
             }
         };
         $rootScope.objectKeys = function (obj) {
-            return Object.keys(obj);
+            if (obj) {
+                return Object.keys(obj);
+            } else {
+                return [];
+            }
         };
         $rootScope.openCentralLogger = function () {
             window.open('http://' + ConfigService.systemConfig.katportal.katlogwebserver).focus();

--- a/app/app.js
+++ b/app/app.js
@@ -595,6 +595,17 @@
             },
             title: 'User Log Reports'
         });
+        $stateProvider.state('utilisation-report', {
+            url: '/utilisation-report/{startTime}/{endTime}/{filter}',
+            templateUrl: 'app/reports/utilisation-report.html',
+            //makes the params optional
+            params: {
+                startTime: { value: null, squash: true },
+                endTime: { value: null, squash: true },
+                filter: { value: null, squash: true }
+            },
+            title: 'Utilisation Report'
+        });
         /* Add New States Above */
         $urlRouterProvider.otherwise('/login');
     }

--- a/app/app.less
+++ b/app/app.less
@@ -24,6 +24,7 @@
 @import "device-status/device-status";
 @import "instrumental-config/instrumental-config";
 @import "userlogs/userlogs";
+@import "reports/utilisation-report";
 /* Add Component LESS Above */
 
 @button-background-gradient: linear-gradient(to bottom, #79a3c9 0%, #4772a0 100%);
@@ -834,6 +835,11 @@ pre {
 .fixed-width-18 {
     min-width: 18px;
     max-width: 18px;
+}
+
+.fixed-width-300 {
+    min-width: 300px;
+    max-width: 300px;
 }
 
 .sb-time-and-type-div {

--- a/app/operator-control/operator-control.html
+++ b/app/operator-control/operator-control.html
@@ -14,9 +14,9 @@
 
         <md-list class="receptor-state-list">
             <md-item ng-repeat="rec in vm.receptorsData">
-                <md-item-content ng-class="{'receptor-state-div-error': rec.since === 'error'}"
+                <md-item-content ng-class="{'receptor-state-div-error': vm.sensorValues[rec.name + '_sensors_ok'].status === 'error', 'receptor-state-div-warn': vm.sensorValues[rec.name + '_sensors_ok'].status === 'warn'}"
                                  class="receptor-state-div md-whiteframe-z2" layout="column"
-                                 layout-align="start center">
+                                 layout-align="start center" title="{{'Sensors ok status: ' + vm.sensorValues[rec.name + '_sensors_ok'].status}}">
                     <span style="min-height: 25px; max-width: 140px;" title="Last Changed; Since: {{rec.since}}">{{rec.fromNow}}</span>
                     <span style="font-size: 26px;" flex><b>{{rec.name}}</b></span>
                     <span class="flash-receptor-state"

--- a/app/operator-control/operator-control.less
+++ b/app/operator-control/operator-control.less
@@ -36,7 +36,7 @@
 
 .receptor-state-div {
     position: relative;
-    background: #259b24;
+    background: #4CAF50;
     color: white;
     min-width: 140px;
     top: 0;
@@ -45,7 +45,12 @@
 }
 
 .receptor-state-div-error {
-    background: #FFC107 !important;
+    background: #F44336 !important;
+    color: black;
+}
+
+.receptor-state-div-warn {
+    background: #FF6F00 !important;
     color: black;
 }
 
@@ -70,4 +75,5 @@
 
 .flash-receptor-state.receptor-stow-state {
     background: #01579b;
+    color: white;
 }

--- a/app/reports/utilisation-report.html
+++ b/app/reports/utilisation-report.html
@@ -34,18 +34,18 @@
                         data-ng-model="vm.endTime" ng-keypress="vm.showEndDatePicker = false" ng-click="$event.stopPropagation()"
                         data-on-set-time="vm.showEndDatePicker = false; vm.onEndTimeSet(vm.endTime)"></datetimepicker>
                 </div>
-                <md-button class="add-tab md-primary md-raised" ng-click="vm.createReport()" ng-disabled="vm.creatingSubarrayReport || vm.creatingReceptorReport"
-                    style="margin-right: 0;">Preview Utilisation Report</md-button>
-                <md-button ng-disabled="vm.reportItems.length === 0 || vm.exportingPdf || vm.creatingSubarrayReport || vm.creatingReceptorReport" class="add-tab md-primary md-raised"
+                <md-button class="add-tab md-primary md-raised" ng-click="vm.createReport()" ng-disabled="vm.creatingSubarrayReport || vm.creatingReceptorReport || vm.creatingScheduleReport"
+                    style="margin-right: 0; min-width: 215px;">{{vm.creatingSubarrayReport || vm.creatingReceptorReport || vm.creatingScheduleReport? 'Creating Report...': 'Preview Utilisation Report'}}</md-button>
+                <md-button ng-disabled="vm.receptorReportResults.length === 0 || vm.exportingPdf || vm.creatingSubarrayReport || vm.creatingReceptorReport || vm.creatingScheduleReport" class="add-tab md-primary md-raised"
                     ng-click="vm.exportPdf()" style="margin-right: 0;">{{vm.exportingPdf? 'Exporting PDF...' : 'Export as PDF'}}
                 </md-button>
             </div>
         </div>
     </md-toolbar>
     <div flex style="overflow: auto" class="md-whiteframe-z1">
-        <div layout="column" ng-show="vm.subarrayReportResults.length > 0">
-            <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Subarray Observations</i>
-            <div class="report-section-title-div" layout="row">
+        <div layout="column" ng-show="vm.subarrayReportResults.length > 0" style="margin-bottom: 8px;">
+            <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Subarray Sensors</i>
+            <div class="report-section-sub-title-div" layout="row">
                 <span style="width: 300px">Sensor</span>
                 <span style="width: 125px" flex>Value</span>
                 <span style="width: 80px; text-align: right; margin-left: 16px">Duration</span>
@@ -61,10 +61,10 @@
                 </div>
             </div>
         </div>
-        <div layout="column" ng-show="vm.receptorReportResults.length > 0" style="margin-bottom: 8px; border-top: 1px solid rgba(127, 127, 127, 0.7)">
-            <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Resources</i>
+        <div layout="column" ng-show="vm.receptorReportResults.length > 0" style="margin-bottom: 8px;">
+            <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Resource Utilisation</i>
             <div layout="column" ng-repeat="subarray in $root.objectKeys(vm.poolResourcesAssignedToSubarraysDurations) | orderBy:subarray track by $index">
-                <div class="report-section-title-div" layout="row">
+                <div class="report-section-sub-title-div" layout="row">
                     <span flex>Assigned to {{subarray}}</span>
                     <span ng-show="$index === 0" style="width: 80px; text-align: right; margin-left: 16px">Duration</span>
                     <span ng-show="$index === 0" style="width: 100px; text-align: right; margin-left: 16px">% of Total</span>
@@ -80,9 +80,8 @@
                         <i>None</i>
                     </div>
                 </div>
-
             </div>
-            <div class="report-section-title-div" layout="row">
+            <div class="report-section-sub-title-div" layout="row">
                 <span flex>Free</span>
             </div>
             <div layout="column">
@@ -93,32 +92,50 @@
                     <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesFreeDurations[key].percentageOfTotal}}</span>
                 </div>
             </div>
-            <div class="report-section-title-div" layout="row">
+            <div class="report-section-sub-title-div" layout="row">
                 <span flex>Faulty</span>
             </div>
             <div layout="column">
                 <div ng-repeat="key in $root.objectKeys(vm.poolResourcesFaultyDurations) | orderBy:key track by $index"
-                    layout="row" class="red-color report-item text-overflow-ellipsis" ng-class="{'light-grey-background-03': $index % 2 == 1}">
+                    layout="row" class="report-item text-overflow-ellipsis" ng-class="{'light-grey-background-03': $index % 2 == 1}">
                     <span flex>{{key}}</span>
                     <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesFaultyDurations[key].duration}}</span>
                     <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesFaultyDurations[key].percentageOfTotal}}</span>
                 </div>
             </div>
-            <div class="report-section-title-div" layout="row">
+            <div class="report-section-sub-title-div" layout="row">
                 <span flex>In Maintenance</span>
             </div>
             <div layout="column">
                 <div ng-repeat="key in $root.objectKeys(vm.poolResourcesMaintenanceDurations) | orderBy:key track by $index"
-                    layout="row" class="report-item text-overflow-ellipsis maintenance-color" ng-class="{'light-grey-background-03': $index % 2 == 1}">
+                    layout="row" class="report-item text-overflow-ellipsis" ng-class="{'light-grey-background-03': $index % 2 == 1}">
                     <span flex>{{key}}</span>
                     <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesMaintenanceDurations[key].duration}}</span>
                     <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesMaintenanceDurations[key].percentageOfTotal}}</span>
                 </div>
             </div>
+            <div layout="column" ng-show="vm.interlockReceptorReportResults.length > 0" style="margin-bottom: 8px;">
+                <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Receptor Modes</i>
+                <div class="report-section-sub-title-div" layout="row">
+                    <span style="width: 300px">Sensor</span>
+                    <span style="width: 125px" flex>Value</span>
+                    <span style="width: 80px; text-align: right; margin-left: 16px">Duration</span>
+                    <span style="width: 100px; text-align: right; margin-left: 16px">% of Total</span>
+                </div>
+                <div layout="column">
+                    <div ng-repeat="item in vm.receptorModeDurations | orderBy:sensorName track by $index"
+                        layout="row" class="report-item text-overflow-ellipsis" ng-class="{'light-grey-background-03': $index % 2 == 1}">
+                        <span class="fixed-width-300" title="{{item.sensorName}}">{{item.sensorName}}</span>
+                        <span flex style="min-width: 200px" title="{{item.value}}">{{item.value}}</span>
+                        <span style="width: 80px; text-align: right; margin-left: 16px">{{item.duration}}</span>
+                        <span style="width: 100px; text-align: right; margin-left: 16px">{{item.percentageOfTotal}}</span>
+                    </div>
+                </div>
+            </div>
         </div>
-        <div layout="column" ng-show="vm.interlockReceptorReportResults.length > 0" style="border-top: 1px solid rgba(127, 127, 127, 0.7)">
+        <div layout="column" ng-show="vm.interlockReceptorReportResults.length > 0" style="margin-bottom: 8px;">
             <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Interlock/Windstow</i>
-            <div class="report-section-title-div" layout="row">
+            <div class="report-section-sub-title-div" layout="row">
                 <span style="width: 300px">Sensor</span>
                 <span style="width: 125px" flex>Value</span>
                 <span style="width: 80px; text-align: right; margin-left: 16px">Duration</span>
@@ -131,6 +148,48 @@
                     <span flex style="min-width: 200px" title="{{item.value}}">{{item.value}}</span>
                     <span style="width: 80px; text-align: right; margin-left: 16px">{{item.duration}}</span>
                     <span style="width: 100px; text-align: right; margin-left: 16px">{{item.percentageOfTotal}}</span>
+                </div>
+            </div>
+        </div>
+        <div layout="column" ng-show="vm.scheduleReportResults.length > 0"  style="margin-bottom: 8px;">
+            <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Active Schedule Blocks</i>
+            <div class="report-section-sub-title-div" layout="row">
+                <span style="width: 300px">Sensor</span>
+                <span style="width: 125px" flex>Value</span>
+                <span style="width: 80px; text-align: right; margin-left: 16px">Duration</span>
+                <span style="width: 100px; text-align: right; margin-left: 16px">% of Total</span>
+            </div>
+            <div layout="column">
+                <div ng-repeat="item in vm.scheduleReportResults | orderBy:sensorName track by $index"
+                    layout="row" class="report-item text-overflow-ellipsis" ng-class="{'light-grey-background-03': $index % 2 == 1}">
+                    <span class="fixed-width-300" title="{{item.sensorName}}">{{item.sensorName}}</span>
+                    <span flex style="min-width: 200px" title="{{item.value}}">{{item.value}}</span>
+                    <span style="width: 80px; text-align: right; margin-left: 16px">{{item.duration}}</span>
+                    <span style="width: 100px; text-align: right; margin-left: 16px">{{item.percentageOfTotal}}</span>
+                </div>
+            </div>
+        </div>
+        <div layout="column" ng-show="vm.scheduleReportResults.length > 0">
+            <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Active Schedule Block Details</i>
+            <div class="report-section-sub-title-div" layout="row">
+                <span style="width: 120px">Id Code</span>
+                <span style="width: 120px">Owner</span>
+                <span style="width: 125px" flex>Description</span>
+                <span style="width: 100px; text-align: right; margin-left: 16px">State</span>
+                <span style="width: 100px; text-align: right; margin-left: 16px">Outcome</span>
+                <span style="width: 100px; text-align: right; margin-left: 16px">Duration</span>
+                <span style="width: 100px; text-align: right; margin-left: 16px">% of Total</span>
+            </div>
+            <div layout="column">
+                <div ng-repeat="sb in vm.SBDetails | orderBy:id_code track by $index"
+                    layout="row" class="report-item text-overflow-ellipsis" ng-class="{'light-grey-background-03': $index % 2 == 1}">
+                    <span style="width: 120px">{{sb.id_code}}</span>
+                    <span style="width: 120px">{{sb.owner}}</span>
+                    <span flex style="min-width: 200px" title="{{sb.description}}">{{sb.description}}</span>
+                    <span style="width: 100px; text-align: right; margin-left: 16px">{{sb.state}}</span>
+                    <span style="width: 100px; text-align: right; margin-left: 16px">{{sb.outcome}}</span>
+                    <span style="width: 100px; text-align: right; margin-left: 16px">{{sb.duration}}</span>
+                    <span style="width: 100px; text-align: right; margin-left: 16px">{{sb.percentageOfTotal}}</span>
                 </div>
             </div>
         </div>

--- a/app/reports/utilisation-report.html
+++ b/app/reports/utilisation-report.html
@@ -53,7 +53,7 @@
             </div>
             <div layout="column">
                 <div ng-repeat="item in vm.subarrayReportResults | orderBy:sensorName track by $index"
-                    layout="row" class="report-item text-overflow-ellipsis">
+                    layout="row" class="report-item text-overflow-ellipsis" ng-class="{'light-grey-background-03': $index % 2 == 1}">
                     <span class="fixed-width-300" title="{{item.sensorName}}">{{item.sensorName}}</span>
                     <span flex style="min-width: 200px" title="{{item.value}}">{{item.value}}</span>
                     <span style="width: 80px; text-align: right; margin-left: 16px">{{item.duration}}</span>
@@ -71,7 +71,7 @@
                 </div>
                 <div layout="column">
                     <div ng-repeat="key in $root.objectKeys(vm.poolResourcesAssignedToSubarraysDurations[subarray]) | orderBy:key track by $index"
-                        layout="row" class="report-item text-overflow-ellipsis">
+                        layout="row" class="report-item text-overflow-ellipsis" ng-class="{'light-grey-background-03': $index % 2 == 1}">
                         <span flex>{{key}}</span>
                         <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesAssignedToSubarraysDurations[subarray][key].duration}}</span>
                         <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesAssignedToSubarraysDurations[subarray][key].percentageOfTotal}}</span>
@@ -87,7 +87,7 @@
             </div>
             <div layout="column">
                 <div ng-repeat="key in $root.objectKeys(vm.poolResourcesFreeDurations) | orderBy:key track by $index"
-                    layout="row" class="report-item text-overflow-ellipsis">
+                    layout="row" class="report-item text-overflow-ellipsis" ng-class="{'light-grey-background-03': $index % 2 == 1}">
                     <span flex>{{key}}</span>
                     <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesFreeDurations[key].duration}}</span>
                     <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesFreeDurations[key].percentageOfTotal}}</span>
@@ -98,7 +98,7 @@
             </div>
             <div layout="column">
                 <div ng-repeat="key in $root.objectKeys(vm.poolResourcesFaultyDurations) | orderBy:key track by $index"
-                    layout="row" class="red-color report-item text-overflow-ellipsis">
+                    layout="row" class="red-color report-item text-overflow-ellipsis" ng-class="{'light-grey-background-03': $index % 2 == 1}">
                     <span flex>{{key}}</span>
                     <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesFaultyDurations[key].duration}}</span>
                     <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesFaultyDurations[key].percentageOfTotal}}</span>
@@ -109,7 +109,7 @@
             </div>
             <div layout="column">
                 <div ng-repeat="key in $root.objectKeys(vm.poolResourcesMaintenanceDurations) | orderBy:key track by $index"
-                    layout="row" class="report-item text-overflow-ellipsis maintenance-color">
+                    layout="row" class="report-item text-overflow-ellipsis maintenance-color" ng-class="{'light-grey-background-03': $index % 2 == 1}">
                     <span flex>{{key}}</span>
                     <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesMaintenanceDurations[key].duration}}</span>
                     <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesMaintenanceDurations[key].percentageOfTotal}}</span>
@@ -126,7 +126,7 @@
             </div>
             <div layout="column">
                 <div ng-repeat="item in vm.interlockReceptorReportResults | orderBy:sensorName track by $index"
-                    layout="row" class="report-item text-overflow-ellipsis">
+                    layout="row" class="report-item text-overflow-ellipsis" ng-class="{'light-grey-background-03': $index % 2 == 1}">
                     <span class="fixed-width-300" title="{{item.sensorName}}">{{item.sensorName}}</span>
                     <span flex style="min-width: 200px" title="{{item.value}}">{{item.value}}</span>
                     <span style="width: 80px; text-align: right; margin-left: 16px">{{item.duration}}</span>

--- a/app/reports/utilisation-report.html
+++ b/app/reports/utilisation-report.html
@@ -1,60 +1,58 @@
-<div flex style="padding: 16px; min-width: 600px" ng-controller="UtilisationReportCtrl as vm">
-    <div layout="column" ng-click="vm.showEndDatePicker = false; vm.showDawtePicker = false;" style="cursor: inherit">
-        <md-toolbar md-theme="{{themePrimary}}" class="md-whiteframe-z1" layout="column">
-            <div md-theme="{{themePrimaryButtons}}" class="md-toolbar-tools" layout="row" layout-align="start center"
-                style="padding: 0">
-                <!-- <span style="margin-left: 8px" flex>Report Parameters</span> -->
-                <div layout="row" layout-align="start center" style="margin: 0 4px; font-size: 14px;">
-                    <div layout="row" layout-align="center center" style="min-width: 180px;">
-                        <md-input-container flex md-no-float style="height: 36px; max-width: 135px; margin: 0; padding: 0;" title="Start Date 'yyyy-MM-dd HH:mm:ss'">
-                            <input flex type="text" style="color: white" title="Start Date 'yyyy-MM-dd HH:mm:ss'" data-ng-model="vm.startDatetimeReadable"
-                                placeholder="Start Date" />
-                        </md-input-container>
-                        <span></span>
-                        <md-button class="md-icon-button" style="margin-left: 0; margin-top: 3px; width: 40px; height: 40px;"
-                            ng-click="vm.showDatePicker = !vm.showDatePicker; vm.showEndDatePicker = false; $event.stopPropagation()">
-                            <md-icon class="fa" md-font-icon="fa-calendar"></md-icon>
-                        </md-button>
-
-                        <datetimepicker id="datePickerMenu" class="datepickerMenu md-whiteframe-z3" ng-init="vm.showDatePicker = false"
-                            style="position: absolute; right: 500px; top: 40px; color: #333333" ng-show="vm.showDatePicker"
-                            data-ng-model="vm.startTime" ng-keypress="vm.showDatePicker = false" ng-click="$event.stopPropagation()"
-                            data-on-set-time="vm.showDatePicker = false; vm.onStartTimeSet(vm.startTime)"></datetimepicker>
-                    </div>
-                    <div layout="row" layout-align="center center" style="min-width: 180px">
-                        <md-input-container flex md-no-float style="height: 36px; max-width: 135px; margin: 0; padding: 0;">
-                            <input flex type="text" style="color: white" data-ng-model="vm.endDatetimeReadable" placeholder="End Date"
-                                title="End Date 'yyyy-MM-dd HH:mm:ss'" />
-                        </md-input-container>
-                        <span></span>
-                        <md-button class="md-icon-button" style="margin-left: 0;width: 40px; height: 40px;" ng-click="vm.showEndDatePicker = !vm.showEndDatePicker; vm.showDatePicker = false; $event.stopPropagation()">
-                            <md-icon class="fa" md-font-icon="fa-calendar"></md-icon>
-                        </md-button>
-                        <datetimepicker id="datePickerMenu" class="datepickerMenu md-whiteframe-z3" ng-init="vm.showEndDatePicker = false"
-                            style="position: absolute; right: 335px; top: 40px; color: #333333" ng-show="vm.showEndDatePicker"
-                            data-ng-model="vm.endTime" ng-keypress="vm.showEndDatePicker = false" ng-click="$event.stopPropagation()"
-                            data-on-set-time="vm.showEndDatePicker = false; vm.onEndTimeSet(vm.endTime)"></datetimepicker>
-                    </div>
-                    <md-button class="add-tab md-primary md-raised" ng-click="vm.createSubarraysReport()" ng-disabled="vm.creatingReport"
-                        style="margin-right: 0;">Preview Subarrays Report</md-button>
-                    <md-button class="add-tab md-primary md-raised" ng-click="vm.createReceptorsReport()" ng-disabled="vm.creatingReport"
-                        style="margin-right: 0;">Preview Receptors Report</md-button>
-                    <md-button ng-disabled="vm.reportItems.length === 0 || vm.exportingPdf" class="add-tab md-primary md-raised"
-                        ng-click="vm.exportPdf()" style="margin-right: 0;">{{vm.exportingPdf? 'Exporting PDF...' : 'TODO: Generate Complete PDF'}}
+<div flex style="padding: 16px; min-width: 600px" ng-controller="UtilisationReportCtrl as vm" layout="column" ng-click="vm.showEndDatePicker = false; vm.showDawtePicker = false;">
+    <md-toolbar md-theme="{{themePrimary}}" class="md-whiteframe-z1" layout="column">
+        <div md-theme="{{themePrimaryButtons}}" class="md-toolbar-tools" layout="row" layout-align="start center"
+            style="padding: 0">
+            <span style="margin-left: 8px" flex>Report Parameters</span>
+            <div layout="row" layout-align="start center" style="margin: 0 4px; font-size: 14px;">
+                <div layout="row" layout-align="center center" style="min-width: 180px;">
+                    <md-input-container flex md-no-float style="height: 36px; max-width: 135px; margin: 0; padding: 0;" title="Start Date 'yyyy-MM-dd HH:mm:ss'">
+                        <input flex type="text" style="color: white" title="Start Date 'yyyy-MM-dd HH:mm:ss'" data-ng-model="vm.startDatetimeReadable"
+                            placeholder="Start Date" />
+                    </md-input-container>
+                    <span></span>
+                    <md-button class="md-icon-button" style="margin-left: 0; margin-top: 3px; width: 40px; height: 40px;"
+                        ng-click="vm.showDatePicker = !vm.showDatePicker; vm.showEndDatePicker = false; $event.stopPropagation()">
+                        <md-icon class="fa" md-font-icon="fa-calendar"></md-icon>
                     </md-button>
+
+                    <datetimepicker id="datePickerMenu" class="datepickerMenu md-whiteframe-z3" ng-init="vm.showDatePicker = false"
+                        style="position: absolute; right: 500px; top: 40px; color: #333333" ng-show="vm.showDatePicker"
+                        data-ng-model="vm.startTime" ng-keypress="vm.showDatePicker = false" ng-click="$event.stopPropagation()"
+                        data-on-set-time="vm.showDatePicker = false; vm.onStartTimeSet(vm.startTime)"></datetimepicker>
                 </div>
+                <div layout="row" layout-align="center center" style="min-width: 180px">
+                    <md-input-container flex md-no-float style="height: 36px; max-width: 135px; margin: 0; padding: 0;">
+                        <input flex type="text" style="color: white" data-ng-model="vm.endDatetimeReadable" placeholder="End Date"
+                            title="End Date 'yyyy-MM-dd HH:mm:ss'" />
+                    </md-input-container>
+                    <span></span>
+                    <md-button class="md-icon-button" style="margin-left: 0;width: 40px; height: 40px;" ng-click="vm.showEndDatePicker = !vm.showEndDatePicker; vm.showDatePicker = false; $event.stopPropagation()">
+                        <md-icon class="fa" md-font-icon="fa-calendar"></md-icon>
+                    </md-button>
+                    <datetimepicker id="datePickerMenu" class="datepickerMenu md-whiteframe-z3" ng-init="vm.showEndDatePicker = false"
+                        style="position: absolute; right: 335px; top: 40px; color: #333333" ng-show="vm.showEndDatePicker"
+                        data-ng-model="vm.endTime" ng-keypress="vm.showEndDatePicker = false" ng-click="$event.stopPropagation()"
+                        data-on-set-time="vm.showEndDatePicker = false; vm.onEndTimeSet(vm.endTime)"></datetimepicker>
+                </div>
+                <md-button class="add-tab md-primary md-raised" ng-click="vm.createReport()" ng-disabled="vm.creatingSubarrayReport || vm.creatingReceptorReport"
+                    style="margin-right: 0;">Preview Utilisation Report</md-button>
+                <md-button ng-disabled="vm.reportItems.length === 0 || vm.exportingPdf || vm.creatingSubarrayReport || vm.creatingReceptorReport" class="add-tab md-primary md-raised"
+                    ng-click="vm.exportPdf()" style="margin-right: 0;">{{vm.exportingPdf? 'Exporting PDF...' : 'Export as PDF'}}
+                </md-button>
             </div>
-        </md-toolbar>
-        <div layout="column" class="md-whiteframe-z1" ng-show="vm.subarrayReportResults.length > 0">
-            <span style="font-size: 22px" class="report-section-title-div">Subarray Section</span>
+        </div>
+    </md-toolbar>
+    <div flex style="overflow: auto" class="md-whiteframe-z1">
+        <div layout="column" ng-show="vm.subarrayReportResults.length > 0">
+            <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Subarray Observations</i>
             <div class="report-section-title-div" layout="row">
                 <span style="width: 300px">Sensor</span>
                 <span style="width: 125px" flex>Value</span>
                 <span style="width: 80px; text-align: right; margin-left: 16px">Duration</span>
                 <span style="width: 100px; text-align: right; margin-left: 16px">% of Total</span>
             </div>
-            <div flex style="overflow: auto" layout="column">
-                <div ng-repeat="item in vm.subarrayReportResults track by $index"
+            <div layout="column">
+                <div ng-repeat="item in vm.subarrayReportResults | orderBy:sensorName track by $index"
                     layout="row" class="report-item text-overflow-ellipsis">
                     <span class="fixed-width-300" title="{{item.sensorName}}">{{item.sensorName}}</span>
                     <span flex style="min-width: 200px" title="{{item.value}}">{{item.value}}</span>
@@ -63,19 +61,18 @@
                 </div>
             </div>
         </div>
-        <div layout="column" ng-show="vm.receptorReportResults.length > 0" class="md-whiteframe-z1" style="margin-bottom: 8px">
-            <span style="font-size: 22px" class="report-section-title-div">Resources Section</span>
-            <div layout="column" ng-repeat="subarray in $root.objectKeys(vm.poolResourcesAssignedToSubarraysDurations) track by $index">
+        <div layout="column" ng-show="vm.receptorReportResults.length > 0" style="margin-bottom: 8px; border-top: 1px solid rgba(127, 127, 127, 0.7)">
+            <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Resources</i>
+            <div layout="column" ng-repeat="subarray in $root.objectKeys(vm.poolResourcesAssignedToSubarraysDurations) | orderBy:subarray track by $index">
                 <div class="report-section-title-div" layout="row">
                     <span flex>Assigned to {{subarray}}</span>
                     <span ng-show="$index === 0" style="width: 80px; text-align: right; margin-left: 16px">Duration</span>
                     <span ng-show="$index === 0" style="width: 100px; text-align: right; margin-left: 16px">% of Total</span>
                 </div>
                 <div layout="column">
-                    <div ng-repeat="key in $root.objectKeys(vm.poolResourcesAssignedToSubarraysDurations[subarray]) | orderBy:key"
+                    <div ng-repeat="key in $root.objectKeys(vm.poolResourcesAssignedToSubarraysDurations[subarray]) | orderBy:key track by $index"
                         layout="row" class="report-item text-overflow-ellipsis">
                         <span flex>{{key}}</span>
-                        <!-- <span flex style="min-width: 200px">{{vm.poolResourcesAssignedToSubarraysDurations[subarray][key].value}}</span> -->
                         <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesAssignedToSubarraysDurations[subarray][key].duration}}</span>
                         <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesAssignedToSubarraysDurations[subarray][key].percentageOfTotal}}</span>
                     </div>
@@ -85,68 +82,50 @@
                 </div>
 
             </div>
-            <!-- <div class="md-whiteframe-z1" style="min-height: 42px; max-height: 42px; padding: 8px; font-size: 18px; font-weight: bold;" layout="row">
-                <span style="width: 300px">Resources assigned to a subarray</span>
-                <span style="width: 125px" flex>Value</span>
-                <span style="width: 80px; text-align: right; margin-left: 16px">Duration</span>
-                <span style="width: 100px; text-align: right; margin-left: 16px">% of Total</span>
-            </div>
-            <div layout="column">
-                <div ng-repeat="key in $root.objectKeys(vm.poolResourcesAssignedDurations)"
-                    layout="row" class="report-item text-overflow-ellipsis">
-                    <span class="fixed-width-300" title="{{key}}">{{key}}</span>
-                    <span flex style="min-width: 200px">{{vm.poolResourcesAssignedDurations[key].value}}</span>
-                    <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesAssignedDurations[key].duration}}</span>
-                    <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesAssignedDurations[key].percentageOfTotal}}</span>
-                </div>
-            </div> -->
             <div class="report-section-title-div" layout="row">
                 <span flex>Free</span>
             </div>
             <div layout="column">
-                <div ng-repeat="key in $root.objectKeys(vm.poolResourcesFreeDurations)"
+                <div ng-repeat="key in $root.objectKeys(vm.poolResourcesFreeDurations) | orderBy:key track by $index"
                     layout="row" class="report-item text-overflow-ellipsis">
                     <span flex>{{key}}</span>
-                    <!-- <span flex style="min-width: 200px">{{vm.poolResourcesFreeDurations[key].value}}</span> -->
                     <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesFreeDurations[key].duration}}</span>
                     <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesFreeDurations[key].percentageOfTotal}}</span>
                 </div>
             </div>
-            <div class="red-color report-section-title-div" layout="row">
+            <div class="report-section-title-div" layout="row">
                 <span flex>Faulty</span>
             </div>
             <div layout="column">
-                <div ng-repeat="key in $root.objectKeys(vm.poolResourcesFaultyDurations)"
-                    layout="row" class="report-item text-overflow-ellipsis">
+                <div ng-repeat="key in $root.objectKeys(vm.poolResourcesFaultyDurations) | orderBy:key track by $index"
+                    layout="row" class="red-color report-item text-overflow-ellipsis">
                     <span flex>{{key}}</span>
-                    <!-- <span flex style="min-width: 200px">{{vm.poolResourcesFaultyDurations[key].value}}</span> -->
                     <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesFaultyDurations[key].duration}}</span>
                     <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesFaultyDurations[key].percentageOfTotal}}</span>
                 </div>
             </div>
-            <div class="maintenance-color report-section-title-div" layout="row">
+            <div class="report-section-title-div" layout="row">
                 <span flex>In Maintenance</span>
             </div>
             <div layout="column">
-                <div ng-repeat="key in $root.objectKeys(vm.poolResourcesMaintenanceDurations)"
-                    layout="row" class="report-item text-overflow-ellipsis">
+                <div ng-repeat="key in $root.objectKeys(vm.poolResourcesMaintenanceDurations) | orderBy:key track by $index"
+                    layout="row" class="report-item text-overflow-ellipsis maintenance-color">
                     <span flex>{{key}}</span>
-                    <!-- <span flex style="min-width: 200px">{{vm.poolResourcesMaintenanceDurations[key].value}}</span> -->
                     <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesMaintenanceDurations[key].duration}}</span>
                     <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesMaintenanceDurations[key].percentageOfTotal}}</span>
                 </div>
             </div>
         </div>
-        <div layout="column" class="md-whiteframe-z1" ng-show="vm.windstowReceptorReportResults.length > 0">
-            <span style="font-size: 22px" class="report-section-title-div">Windstow Section</span>
+        <div layout="column" ng-show="vm.interlockReceptorReportResults.length > 0" style="border-top: 1px solid rgba(127, 127, 127, 0.7)">
+            <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Interlock/Windstow</i>
             <div class="report-section-title-div" layout="row">
                 <span style="width: 300px">Sensor</span>
                 <span style="width: 125px" flex>Value</span>
                 <span style="width: 80px; text-align: right; margin-left: 16px">Duration</span>
                 <span style="width: 100px; text-align: right; margin-left: 16px">% of Total</span>
             </div>
-            <div flex style="overflow: auto" layout="column">
-                <div ng-repeat="item in vm.windstowReceptorReportResults track by $index"
+            <div layout="column">
+                <div ng-repeat="item in vm.interlockReceptorReportResults | orderBy:sensorName track by $index"
                     layout="row" class="report-item text-overflow-ellipsis">
                     <span class="fixed-width-300" title="{{item.sensorName}}">{{item.sensorName}}</span>
                     <span flex style="min-width: 200px" title="{{item.value}}">{{item.value}}</span>

--- a/app/reports/utilisation-report.html
+++ b/app/reports/utilisation-report.html
@@ -135,7 +135,9 @@
         <div layout="column" style="margin-bottom: 8px;">
             <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Resource Utilisation</i>
             <div layout="row">
-                <i class="report-row-column-item">Subarray</i>
+                <i class="report-row-column-item"></i>
+                <i class="report-column-value-item">Total Duration</i>
+                <i class="report-column-value-item">Total %</i>
                 <b ng-repeat="key in vm.resourceItemColumns" class="report-column-value-item">
                     {{key}}
                 </b>
@@ -148,7 +150,13 @@
                 </div>
                 <div layout="column">
                     <div ng-repeat="key in $root.objectKeys(vm.poolResourcesAssignedDurations) | orderBy:key" layout="row" class="report-item">
-                        <div ng-repeat="column in $root.objectKeys(vm.poolResourcesAssignedDurations[key]) | orderBy:column" class="report-cell-item" title="{{vm.poolResourcesAssignedDurations[key][column].value + ' ' + vm.poolResourcesAssignedDurations[key][column].duration}}">
+                        <div class="report-cell-item" title="Total utilisation in hours for all subarrays">
+                            {{vm.poolResourcesAssignedDurations[key].durationTotal}}
+                        </div>
+                        <div class="report-cell-item" title="Total utilisation percentage for all subarrays">
+                            {{vm.poolResourcesAssignedDurations[key].percentageTotal}}
+                        </div>
+                        <div ng-repeat="column in vm.resourceItemColumns | orderBy:column" class="report-cell-item" title="{{vm.poolResourcesAssignedDurations[key][column].duration}}">
                             {{vm.poolResourcesAssignedDurations[key][column].percentageOfTotal}}
                         </div>
                     </div>
@@ -158,16 +166,20 @@
         <div layout="column" style="margin-bottom: 8px;">
             <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">System State</i>
             <div layout="row">
-                <b class="report-row-column-item"></b>
+                <b class="report-row-column-item">Interlock State</b>
                 <div class="report-column-value-item" ng-repeat="key in $root.objectKeys(vm.interlockReceptorReportResults)">
                     {{key}}
                 </div>
             </div>
             <div layout="row">
-                <b class="report-row-column-item">Interlock State</b>
                 <div layout="column">
-                    <div ng-repeat="key in $root.objectKeys(vm.interlockReceptorReportResults)" class="report-cell-item" class="report-item">
-                        {{vm.interlockReceptorReportResults[key].percentageOfTotal}}
+                    <span class="report-row-value-item">Percentage</span>
+                    <span class="report-row-value-item">Duration</span>
+                </div>
+                <div layout="column">
+                    <div ng-repeat="key in $root.objectKeys(vm.interlockReceptorReportResults)" layout="column">
+                        <div class="report-cell-item report-item">{{vm.interlockReceptorReportResults[key].percentageOfTotal}}</div>
+                        <div class="report-cell-item report-item">{{vm.interlockReceptorReportResults[key].duration}}</div>
                     </div>
                 </div>
             </div>

--- a/app/reports/utilisation-report.html
+++ b/app/reports/utilisation-report.html
@@ -167,7 +167,7 @@
             <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">System State</i>
             <div layout="row">
                 <b class="report-row-column-item">Interlock State</b>
-                <div class="report-column-value-item" ng-repeat="key in $root.objectKeys(vm.interlockReceptorReportResults)">
+                <div class="report-column-value-item-long" ng-repeat="key in $root.objectKeys(vm.interlockReceptorReportResults)">
                     {{key}}
                 </div>
             </div>
@@ -176,10 +176,10 @@
                     <span class="report-row-value-item">Percentage</span>
                     <span class="report-row-value-item">Duration</span>
                 </div>
-                <div layout="column">
+                <div layout="row">
                     <div ng-repeat="key in $root.objectKeys(vm.interlockReceptorReportResults)" layout="column">
-                        <div class="report-cell-item report-item">{{vm.interlockReceptorReportResults[key].percentageOfTotal}}</div>
-                        <div class="report-cell-item report-item">{{vm.interlockReceptorReportResults[key].duration}}</div>
+                        <div class="report-cell-item-long report-item">{{vm.interlockReceptorReportResults[key].percentageOfTotal}}</div>
+                        <div class="report-cell-item-long report-item">{{vm.interlockReceptorReportResults[key].duration}}</div>
                     </div>
                 </div>
             </div>
@@ -198,7 +198,7 @@
             </div>
             <div layout="column">
                 <div ng-repeat="sb in vm.SBDetails | orderBy:id_code track by $index"
-                    layout="row" class="report-item text-overflow-ellipsis" ng-class="{'light-grey-background-03': $index % 2 == 1}">
+                    layout="row" class="report-sb-item text-overflow-ellipsis" ng-class="{'light-grey-background-03': $index % 2 == 1}">
                     <span style="width: 120px">{{sb.id_code}}</span>
                     <span style="width: 120px">{{sb.owner}}</span>
                     <span flex style="min-width: 200px" title="{{sb.description}}">{{sb.description}}</span>

--- a/app/reports/utilisation-report.html
+++ b/app/reports/utilisation-report.html
@@ -1,20 +1,20 @@
-<div flex style="padding: 16px; min-width: 600px" ng-controller="UtilisationReportCtrl as vm" layout="row">
-    <div flex layout="column" ng-click="vm.showEndDatePicker = false; vm.showDawtePicker = false;"
-        style="cursor: inherit">
+<div flex style="padding: 16px; min-width: 600px" ng-controller="UtilisationReportCtrl as vm">
+    <div layout="column" ng-click="vm.showEndDatePicker = false; vm.showDawtePicker = false;" style="cursor: inherit">
         <md-toolbar md-theme="{{themePrimary}}" class="md-whiteframe-z1" layout="column">
-            <div md-theme="{{themePrimaryButtons}}" class="md-toolbar-tools" layout="row" layout-align="start center" style="padding: 0">
-                <span style="margin-left: 8px" flex>Report Parameters</span>
-                <input class="fade-in search-input-box" style="width: 200px; max-width: 200px" type="search"
-                       ng-model-options="{ debounce: 300 }" ng-model="vm.searchInputText" placeholder="Filter items..."/>
+            <div md-theme="{{themePrimaryButtons}}" class="md-toolbar-tools" layout="row" layout-align="start center"
+                style="padding: 0">
+                <!-- <span style="margin-left: 8px" flex>Report Parameters</span> -->
+                <input class="fade-in search-input-box" style="margin-left: 8px; width: 200px; max-width: 200px" type="search" ng-model-options="{ debounce: 300 }"
+                    ng-model="vm.searchInputText" placeholder="Filter items..." />
                 <div layout="row" layout-align="start center" style="margin: 0 4px; font-size: 14px;">
                     <div layout="row" layout-align="center center" style="min-width: 180px;">
                         <md-input-container flex md-no-float style="height: 36px; max-width: 135px; margin: 0; padding: 0;" title="Start Date 'yyyy-MM-dd HH:mm:ss'">
-                            <input flex type="text" style="color: white" title="Start Date 'yyyy-MM-dd HH:mm:ss'"
-                                   data-ng-model="vm.startDatetimeReadable" placeholder="Start Date"/>
+                            <input flex type="text" style="color: white" title="Start Date 'yyyy-MM-dd HH:mm:ss'" data-ng-model="vm.startDatetimeReadable"
+                                placeholder="Start Date" />
                         </md-input-container>
                         <span></span>
                         <md-button class="md-icon-button" style="margin-left: 0; margin-top: 3px; width: 40px; height: 40px;"
-                                   ng-click="vm.showDatePicker = !vm.showDatePicker; vm.showEndDatePicker = false; $event.stopPropagation()">
+                            ng-click="vm.showDatePicker = !vm.showDatePicker; vm.showEndDatePicker = false; $event.stopPropagation()">
                             <md-icon class="fa" md-font-icon="fa-calendar"></md-icon>
                         </md-button>
 
@@ -25,13 +25,11 @@
                     </div>
                     <div layout="row" layout-align="center center" style="min-width: 180px">
                         <md-input-container flex md-no-float style="height: 36px; max-width: 135px; margin: 0; padding: 0;">
-                            <input flex type="text" style="color: white"
-                                   data-ng-model="vm.endDatetimeReadable" placeholder="End Date"
-                                   title="End Date 'yyyy-MM-dd HH:mm:ss'"/>
+                            <input flex type="text" style="color: white" data-ng-model="vm.endDatetimeReadable" placeholder="End Date"
+                                title="End Date 'yyyy-MM-dd HH:mm:ss'" />
                         </md-input-container>
                         <span></span>
-                        <md-button class="md-icon-button" style="margin-left: 0;width: 40px; height: 40px;"
-                                   ng-click="vm.showEndDatePicker = !vm.showEndDatePicker; vm.showDatePicker = false; $event.stopPropagation()">
+                        <md-button class="md-icon-button" style="margin-left: 0;width: 40px; height: 40px;" ng-click="vm.showEndDatePicker = !vm.showEndDatePicker; vm.showDatePicker = false; $event.stopPropagation()">
                             <md-icon class="fa" md-font-icon="fa-calendar"></md-icon>
                         </md-button>
                         <datetimepicker id="datePickerMenu" class="datepickerMenu md-whiteframe-z3" ng-init="vm.showEndDatePicker = false"
@@ -39,52 +37,98 @@
                             data-ng-model="vm.endTime" ng-keypress="vm.showEndDatePicker = false" ng-click="$event.stopPropagation()"
                             data-on-set-time="vm.showEndDatePicker = false; vm.onEndTimeSet(vm.endTime)"></datetimepicker>
                     </div>
-                    <md-button class="add-tab md-primary md-raised" ng-click="vm.createReport(event)"
-                               style="margin-right: 0;">Create Report
-                    </md-button>
-                    <md-button ng-disabled="vm.reportItems.length === 0 || vm.exportingPdf" class="add-tab md-primary md-raised" ng-click="vm.exportPdf()"
-                               style="margin-right: 0;">{{vm.exportingPdf? 'Exporting PDF...' : 'Export as PDF'}}
+                    <md-button class="add-tab md-primary md-raised" ng-click="vm.createSubarraysReport()" ng-disabled="vm.creatingReport"
+                        style="margin-right: 0;">Preview Subarrays Report</md-button>
+                    <md-button class="add-tab md-primary md-raised" ng-click="vm.createReceptorsReport()" ng-disabled="vm.creatingReport"
+                        style="margin-right: 0;">Preview Receptors Report</md-button>
+                    <md-button ng-disabled="vm.reportItems.length === 0 || vm.exportingPdf" class="add-tab md-primary md-raised"
+                        ng-click="vm.exportPdf()" style="margin-right: 0;">{{vm.exportingPdf? 'Exporting PDF...' : 'TODO: Generate Complete PDF'}}
                     </md-button>
                 </div>
             </div>
         </md-toolbar>
-        <div flex style="overflow: auto" layout="column" class="md-whiteframe-z1">
-            <div ng-repeat="result in vm.results" layout="row">
-                <span style="min-width: 400px">{{result[0]}}</span>
-                <span flex style="min-width: 200px; overflow: hidden; text-overflow: ellipsis">{{result[1]}}</span>
-                <span style="min-width: 200px">{{vm.momentDuration(result[2])}}</span>
+        <div flex layout="column" class="md-whiteframe-z1" ng-show="vm.subarrayReportResults.length > 0">
+            <div class="md-whiteframe-z1" style="min-height: 42px; max-height: 42px; padding: 8px; font-size: 18px; font-weight: bold;" layout="row">
+                <span style="width: 300px">Sensor</span>
+                <span style="width: 125px" flex>Value</span>
+                <span style="width: 80px; text-align: right; margin-left: 16px">Duration</span>
+                <span style="width: 100px; text-align: right; margin-left: 16px">% of Total</span>
+            </div>
+            <div flex style="overflow: auto" layout="column">
+                <div ng-repeat="item in vm.subarrayReportResults | regexSearch:vm.reportFields:vm.searchInputText track by $index"
+                    layout="row" class="report-item text-overflow-ellipsis">
+                    <span class="fixed-width-300" title="{{item.sensorName}}">{{item.sensorName}}</span>
+                    <span flex style="min-width: 200px" title="{{item.value}}">{{item.value}}</span>
+                    <span style="width: 80px; text-align: right; margin-left: 16px">{{item.duration}}</span>
+                    <span style="width: 100px; text-align: right; margin-left: 16px">{{item.percentageOfTotal}}</span>
+                </div>
             </div>
         </div>
-        <!-- <div layout="column" class="md-whiteframe-z1" style="overflow: auto" ng-show="vm.reportItems.length > 0">
-            <div class="md-list-item-text" style="min-height: 42px; max-height: 42px; padding: 8px; border-bottom: 1px solid currentColor; font-size: 18px; font-weight: bold;" layout="row" flex>
-                <span style="width: 130px; margin: 0 4px">User</span>
-                <span style="width: 125px">Start</span>
-                <span style="width: 125px">End</span>
-                <span flex>Content</span>
-                <span style="margin-right: 32px">Tags</span>
-            </div> -->
-            <!-- <div ng-repeat="userlog in vm.filteredReportUserlogs = (vm.reportUserlogs | regexSearch:vm.userLogsFields:vm.searchInputText | filter:vm.filterByTag) track by $index" ng-click="vm.editUserLog(userlog, $event)" class="user-log-row"> -->
-                <!-- <div layout="row" layout-align="start center" style="position: relative; border-top: 1px solid #d7d7d7" title="{{userlog.content}}">
-                    <i class="userlog-user-name" title="{{userlog.user.name}}">
-                        <b>{{userlog.user.name}}</b>
-                    </i>
-                    <span style="width: 125px; font-size: 12px">
-                        {{userlog.start_time}}
-                    </span>
-                    <span style="width: 125px; font-size: 12px">
-                        {{userlog.end_time}}
-                    </span>
-                    <pre flex ng-class="{'compressed-userlog': !vm.expandEntries}" style="margin: 0; padding: 0; background: transparent; margin-bottom: 8px; min-height: 33px;" ng-bind-html="userlog.content | linkify | toTrustedHtml"></pre>
-                    <div class="tags-list-container" title="{{userlog.tagsListText}}" ng-class="{'tags-list-compressed-container': !vm.expandEntries}">
-                        <i style="font-size: 11px; padding-right: 2px">{{userlog.tagsListText}}</i>
-                    </div>
-                    <span style="min-width: 24px; margin-left: 8px; font-size: 12px">
-                        <span ng-show="userlog.attachment_count>0">({{userlog.attachment_count}}
-                        <span class="fa fa-paperclip"></span>)
-                        </span>
-                    </span>
-                </div> -->
-            <!-- </div> -->
-        <!-- </div> -->
+        <div layout="column" class="md-whiteframe-z1" ng-repeat="subarray in $root.objectKeys(vm.poolResourcesAssignedToSubarraysDurations) track by $index">
+            <div class="md-whiteframe-z1" style="min-height: 42px; max-height: 42px; padding: 8px; font-size: 18px; font-weight: bold;" layout="row">
+                <span style="width: 300px">Resources assigned to {{subarray}}</span>
+            </div>
+            <div layout="column">
+                <div ng-repeat="key in $root.objectKeys(vm.poolResourcesAssignedToSubarraysDurations[subarray]) | orderBy:key"
+                    layout="row" class="report-item text-overflow-ellipsis">
+                    <span class="fixed-width-300" title="{{key}}">{{key}}</span>
+                    <span flex style="min-width: 200px">{{vm.poolResourcesAssignedToSubarraysDurations[subarray][key].value}}</span>
+                    <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesAssignedToSubarraysDurations[subarray][key].duration}}</span>
+                    <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesAssignedToSubarraysDurations[subarray][key].percentageOfTotal}}</span>
+                </div>
+            </div>
+
+        </div>
+        <!-- <div class="md-whiteframe-z1" style="min-height: 42px; max-height: 42px; padding: 8px; font-size: 18px; font-weight: bold;" layout="row">
+            <span style="width: 300px">Resources assigned to a subarray</span>
+            <span style="width: 125px" flex>Value</span>
+            <span style="width: 80px; text-align: right; margin-left: 16px">Duration</span>
+            <span style="width: 100px; text-align: right; margin-left: 16px">% of Total</span>
+        </div>
+        <div layout="column">
+            <div ng-repeat="key in $root.objectKeys(vm.poolResourcesAssignedDurations)"
+                layout="row" class="report-item text-overflow-ellipsis">
+                <span class="fixed-width-300" title="{{key}}">{{key}}</span>
+                <span flex style="min-width: 200px">{{vm.poolResourcesAssignedDurations[key].value}}</span>
+                <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesAssignedDurations[key].duration}}</span>
+                <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesAssignedDurations[key].percentageOfTotal}}</span>
+            </div>
+        </div> -->
+        <div class="md-whiteframe-z1 report-section-title-div">
+            Free Resources
+        </div>
+        <div layout="column">
+            <div ng-repeat="key in $root.objectKeys(vm.poolResourcesFreeDurations)"
+                layout="row" class="report-item text-overflow-ellipsis">
+                <span class="fixed-width-300" title="{{key}}">{{key}}</span>
+                <span flex style="min-width: 200px">{{vm.poolResourcesFreeDurations[key].value}}</span>
+                <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesFreeDurations[key].duration}}</span>
+                <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesFreeDurations[key].percentageOfTotal}}</span>
+            </div>
+        </div>
+        <div class="md-whiteframe-z1 report-section-title-div">
+            Faulty Resources
+        </div>
+        <div layout="column">
+            <div ng-repeat="key in $root.objectKeys(vm.poolResourcesFaultyDurations)"
+                layout="row" class="report-item text-overflow-ellipsis">
+                <span class="fixed-width-300" title="{{key}}">{{key}}</span>
+                <span flex style="min-width: 200px">{{vm.poolResourcesFaultyDurations[key].value}}</span>
+                <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesFaultyDurations[key].duration}}</span>
+                <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesFaultyDurations[key].percentageOfTotal}}</span>
+            </div>
+        </div>
+        <div class="md-whiteframe-z1 report-section-title-div">
+            In Maintenance Resources
+        </div>
+        <div layout="column">
+            <div ng-repeat="key in $root.objectKeys(vm.poolResourcesMaintenanceDurations)"
+                layout="row" class="report-item text-overflow-ellipsis">
+                <span class="fixed-width-300" title="{{key}}">{{key}}</span>
+                <span flex style="min-width: 200px">{{vm.poolResourcesMaintenanceDurations[key].value}}</span>
+                <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesMaintenanceDurations[key].duration}}</span>
+                <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesMaintenanceDurations[key].percentageOfTotal}}</span>
+            </div>
+        </div>
     </div>
 </div>

--- a/app/reports/utilisation-report.html
+++ b/app/reports/utilisation-report.html
@@ -43,11 +43,10 @@
         </div>
     </md-toolbar>
     <div flex style="overflow: auto" class="md-whiteframe-z1">
-
         <div layout="column" style="margin-bottom: 8px;">
             <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Scheduler Mode</i>
             <div layout="row">
-                <i class="report-row-column-item">Subarrays</i>
+                <i class="report-row-column-item">Subarray</i>
                 <b ng-repeat="subNr in vm.subarrayNrs" class="report-column-value-item">
                     {{subNr}}
                 </b>
@@ -59,7 +58,7 @@
                     </div>
                 </div>
                 <div layout="column">
-                    <div ng-repeat="key in $root.objectKeys(vm.schedModeDurations)" layout="row">
+                    <div ng-repeat="key in $root.objectKeys(vm.schedModeDurations)" layout="row" class="report-item">
                         <div ng-repeat="subNr in $root.objectKeys(vm.schedModeDurations[key]) | orderBy:subNr" class="report-cell-item" title="{{vm.schedModeDurations[key][subNr].duration}}">
                             {{vm.schedModeDurations[key][subNr].percentageOfTotal}}
                         </div>
@@ -67,11 +66,10 @@
                 </div>
             </div>
         </div>
-
         <div layout="column" style="margin-bottom: 8px;">
-            <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Subarrays</i>
+            <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Subarray</i>
             <div layout="row">
-                <i class="report-row-column-item">Subarrays</i>
+                <i class="report-row-column-item">Subarray</i>
                 <b ng-repeat="subNr in vm.subarrayNrs" class="report-column-value-item">
                     {{subNr}}
                 </b>
@@ -92,7 +90,7 @@
                     </div>
                 </div>
                 <div layout="column">
-                    <div ng-repeat="key in $root.objectKeys(vm.subarrayStateDurations)" layout="row">
+                    <div ng-repeat="key in $root.objectKeys(vm.subarrayStateDurations)" layout="row" class="report-item">
                         <div ng-repeat="subNr in $root.objectKeys(vm.subarrayStateDurations[key]) | orderBy:subNr" class="report-cell-item" title="{{vm.subarrayStateDurations[key][subNr].duration}}">
                             {{vm.subarrayStateDurations[key][subNr].percentageOfTotal}}
                         </div>
@@ -109,7 +107,7 @@
                     </div>
                 </div>
                 <div layout="column">
-                    <div ng-repeat="key in $root.objectKeys(vm.subarrayBandDurations)" layout="row">
+                    <div ng-repeat="key in $root.objectKeys(vm.subarrayBandDurations)" layout="row" class="report-item">
                         <div ng-repeat="subNr in $root.objectKeys(vm.subarrayBandDurations[key]) | orderBy:subNr" class="report-cell-item" title="{{vm.subarrayBandDurations[key][subNr].duration}}">
                             {{vm.subarrayBandDurations[key][subNr].percentageOfTotal}}
                         </div>
@@ -126,7 +124,7 @@
                     </div>
                 </div>
                 <div layout="column">
-                    <div ng-repeat="key in $root.objectKeys(vm.subarrayProductDurations)" layout="row">
+                    <div ng-repeat="key in $root.objectKeys(vm.subarrayProductDurations)" layout="row" class="report-item">
                         <div ng-repeat="subNr in $root.objectKeys(vm.subarrayProductDurations[key]) | orderBy:subNr" class="report-cell-item" title="{{vm.subarrayProductDurations[key][subNr].duration}}">
                             {{vm.subarrayProductDurations[key][subNr].percentageOfTotal}}
                         </div>
@@ -134,139 +132,53 @@
                 </div>
             </div>
         </div>
-
-        <!-- <div layout="column" ng-show="vm.subarrayReportResults.length > 0" style="margin-bottom: 8px;">
-            <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Subarray Sensors</i>
-            <div class="report-section-sub-title-div" layout="row">
-                <span style="width: 300px">Sensor</span>
-                <span style="width: 125px" flex>Value</span>
-                <span style="width: 80px; text-align: right; margin-left: 16px">Duration</span>
-                <span style="width: 100px; text-align: right; margin-left: 16px">% of Total</span>
-            </div>
-            <div layout="column">
-                <div ng-repeat="item in vm.subarrayReportResults | orderBy:sensorName track by $index"
-                    layout="row" class="report-item text-overflow-ellipsis" ng-class="{'light-grey-background-03': $index % 2 == 1}">
-                    <span class="fixed-width-300" title="{{item.sensorName}}">{{item.sensorName}}</span>
-                    <span flex style="min-width: 200px" title="{{item.value}}">{{item.value}}</span>
-                    <span style="width: 80px; text-align: right; margin-left: 16px">{{item.duration}}</span>
-                    <span style="width: 100px; text-align: right; margin-left: 16px">{{item.percentageOfTotal}}</span>
-                </div>
-            </div>
-        </div> -->
-        <div layout="column" ng-show="vm.receptorReportResults.length > 0" style="margin-bottom: 8px;">
+        <div layout="column" style="margin-bottom: 8px;">
             <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Resource Utilisation</i>
-            <div layout="column" ng-repeat="subarray in $root.objectKeys(vm.poolResourcesAssignedToSubarraysDurations) | orderBy:subarray track by $index">
-                <div class="report-section-sub-title-div" layout="row">
-                    <span flex>Assigned to {{subarray}}</span>
-                    <span ng-show="$index === 0" style="width: 80px; text-align: right; margin-left: 16px">Duration</span>
-                    <span ng-show="$index === 0" style="width: 100px; text-align: right; margin-left: 16px">% of Total</span>
+            <div layout="row">
+                <i class="report-row-column-item">Subarray</i>
+                <b ng-repeat="key in vm.resourceItemColumns" class="report-column-value-item">
+                    {{key}}
+                </b>
+            </div>
+            <div layout="row">
+                <div layout="column">
+                    <div ng-repeat="key in $root.objectKeys(vm.poolResourcesAssignedDurations) | orderBy:key" class="report-row-value-item">
+                        {{key}}
+                    </div>
                 </div>
                 <div layout="column">
-                    <div ng-repeat="key in $root.objectKeys(vm.poolResourcesAssignedToSubarraysDurations[subarray]) | orderBy:key track by $index"
-                        layout="row" class="report-item text-overflow-ellipsis" ng-class="{'light-grey-background-03': $index % 2 == 1}">
-                        <span flex>{{key}}</span>
-                        <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesAssignedToSubarraysDurations[subarray][key].duration}}</span>
-                        <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesAssignedToSubarraysDurations[subarray][key].percentageOfTotal}}</span>
-                    </div>
-                    <div class="report-item" ng-show="$root.objectKeys(vm.poolResourcesAssignedToSubarraysDurations[subarray]).length === 0">
-                        <i>None</i>
+                    <div ng-repeat="key in $root.objectKeys(vm.poolResourcesAssignedDurations) | orderBy:key" layout="row" class="report-item">
+                        <div ng-repeat="column in $root.objectKeys(vm.poolResourcesAssignedDurations[key]) | orderBy:column" class="report-cell-item" title="{{vm.poolResourcesAssignedDurations[key][column].value + ' ' + vm.poolResourcesAssignedDurations[key][column].duration}}">
+                            {{vm.poolResourcesAssignedDurations[key][column].percentageOfTotal}}
+                        </div>
                     </div>
                 </div>
             </div>
-            <div class="report-section-sub-title-div" layout="row">
-                <span flex>Free</span>
-            </div>
-            <div layout="column">
-                <div ng-repeat="key in $root.objectKeys(vm.poolResourcesFreeDurations) | orderBy:key track by $index"
-                    layout="row" class="report-item text-overflow-ellipsis" ng-class="{'light-grey-background-03': $index % 2 == 1}">
-                    <span flex>{{key}}</span>
-                    <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesFreeDurations[key].duration}}</span>
-                    <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesFreeDurations[key].percentageOfTotal}}</span>
+        </div>
+        <div layout="column" style="margin-bottom: 8px;">
+            <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">System State</i>
+            <div layout="row">
+                <b class="report-row-column-item"></b>
+                <div class="report-column-value-item" ng-repeat="key in $root.objectKeys(vm.interlockReceptorReportResults)">
+                    {{key}}
                 </div>
             </div>
-            <div class="report-section-sub-title-div" layout="row">
-                <span flex>Faulty</span>
-            </div>
-            <div layout="column">
-                <div ng-repeat="key in $root.objectKeys(vm.poolResourcesFaultyDurations) | orderBy:key track by $index"
-                    layout="row" class="report-item text-overflow-ellipsis" ng-class="{'light-grey-background-03': $index % 2 == 1}">
-                    <span flex>{{key}}</span>
-                    <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesFaultyDurations[key].duration}}</span>
-                    <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesFaultyDurations[key].percentageOfTotal}}</span>
-                </div>
-            </div>
-            <div class="report-section-sub-title-div" layout="row">
-                <span flex>In Maintenance</span>
-            </div>
-            <div layout="column">
-                <div ng-repeat="key in $root.objectKeys(vm.poolResourcesMaintenanceDurations) | orderBy:key track by $index"
-                    layout="row" class="report-item text-overflow-ellipsis" ng-class="{'light-grey-background-03': $index % 2 == 1}">
-                    <span flex>{{key}}</span>
-                    <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesMaintenanceDurations[key].duration}}</span>
-                    <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesMaintenanceDurations[key].percentageOfTotal}}</span>
-                </div>
-            </div>
-            <!-- <div layout="column" ng-show="vm.interlockReceptorReportResults.length > 0" style="margin-bottom: 8px;">
-                <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Receptor Modes</i>
-                <div class="report-section-sub-title-div" layout="row">
-                    <span style="width: 300px">Sensor</span>
-                    <span style="width: 125px" flex>Value</span>
-                    <span style="width: 80px; text-align: right; margin-left: 16px">Duration</span>
-                    <span style="width: 100px; text-align: right; margin-left: 16px">% of Total</span>
-                </div>
+            <div layout="row">
+                <b class="report-row-column-item">Interlock State</b>
                 <div layout="column">
-                    <div ng-repeat="item in vm.receptorModeDurations | orderBy:sensorName track by $index"
-                        layout="row" class="report-item text-overflow-ellipsis" ng-class="{'light-grey-background-03': $index % 2 == 1}">
-                        <span class="fixed-width-300" title="{{item.sensorName}}">{{item.sensorName}}</span>
-                        <span flex style="min-width: 200px" title="{{item.value}}">{{item.value}}</span>
-                        <span style="width: 80px; text-align: right; margin-left: 16px">{{item.duration}}</span>
-                        <span style="width: 100px; text-align: right; margin-left: 16px">{{item.percentageOfTotal}}</span>
+                    <div ng-repeat="key in $root.objectKeys(vm.interlockReceptorReportResults)" class="report-cell-item" class="report-item">
+                        {{vm.interlockReceptorReportResults[key].percentageOfTotal}}
                     </div>
                 </div>
-            </div> -->
-        </div>
-        <div layout="column" ng-show="vm.interlockReceptorReportResults.length > 0" style="margin-bottom: 8px;">
-            <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Interlock/Windstow</i>
-            <div class="report-section-sub-title-div" layout="row">
-                <span style="width: 300px">Sensor</span>
-                <span style="width: 125px" flex>Value</span>
-                <span style="width: 80px; text-align: right; margin-left: 16px">Duration</span>
-                <span style="width: 100px; text-align: right; margin-left: 16px">% of Total</span>
-            </div>
-            <div layout="column">
-                <div ng-repeat="item in vm.interlockReceptorReportResults | orderBy:sensorName track by $index"
-                    layout="row" class="report-item text-overflow-ellipsis" ng-class="{'light-grey-background-03': $index % 2 == 1}">
-                    <span class="fixed-width-300" title="{{item.sensorName}}">{{item.sensorName}}</span>
-                    <span flex style="min-width: 200px" title="{{item.value}}">{{item.value}}</span>
-                    <span style="width: 80px; text-align: right; margin-left: 16px">{{item.duration}}</span>
-                    <span style="width: 100px; text-align: right; margin-left: 16px">{{item.percentageOfTotal}}</span>
-                </div>
             </div>
         </div>
-        <div layout="column" ng-show="vm.scheduleReportResults.length > 0"  style="margin-bottom: 8px;">
-            <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Active Schedule Blocks</i>
-            <div class="report-section-sub-title-div" layout="row">
-                <span style="width: 300px">Sensor</span>
-                <span style="width: 125px" flex>Value</span>
-                <span style="width: 80px; text-align: right; margin-left: 16px">Duration</span>
-                <span style="width: 100px; text-align: right; margin-left: 16px">% of Total</span>
-            </div>
-            <div layout="column">
-                <div ng-repeat="item in vm.scheduleReportResults | orderBy:sensorName track by $index"
-                    layout="row" class="report-item text-overflow-ellipsis" ng-class="{'light-grey-background-03': $index % 2 == 1}">
-                    <span class="fixed-width-300" title="{{item.sensorName}}">{{item.sensorName}}</span>
-                    <span flex style="min-width: 200px" title="{{item.value}}">{{item.value}}</span>
-                    <span style="width: 80px; text-align: right; margin-left: 16px">{{item.duration}}</span>
-                    <span style="width: 100px; text-align: right; margin-left: 16px">{{item.percentageOfTotal}}</span>
-                </div>
-            </div>
-        </div>
-        <div layout="column" ng-show="vm.scheduleReportResults.length > 0">
+        <div layout="column">
             <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Active Schedule Block Details</i>
             <div class="report-section-sub-title-div" layout="row">
                 <span style="width: 120px">Id Code</span>
                 <span style="width: 120px">Owner</span>
                 <span style="width: 125px" flex>Description</span>
+                <span style="width: 100px; text-align: right; margin-left: 16px">Subarray</span>
                 <span style="width: 100px; text-align: right; margin-left: 16px">State</span>
                 <span style="width: 100px; text-align: right; margin-left: 16px">Outcome</span>
                 <span style="width: 100px; text-align: right; margin-left: 16px">Duration</span>
@@ -278,6 +190,7 @@
                     <span style="width: 120px">{{sb.id_code}}</span>
                     <span style="width: 120px">{{sb.owner}}</span>
                     <span flex style="min-width: 200px" title="{{sb.description}}">{{sb.description}}</span>
+                    <span style="width: 100px; text-align: right; margin-left: 16px">{{sb.sub_nr}}</span>
                     <span style="width: 100px; text-align: right; margin-left: 16px">{{sb.state}}</span>
                     <span style="width: 100px; text-align: right; margin-left: 16px">{{sb.outcome}}</span>
                     <span style="width: 100px; text-align: right; margin-left: 16px">{{sb.duration}}</span>

--- a/app/reports/utilisation-report.html
+++ b/app/reports/utilisation-report.html
@@ -2,7 +2,7 @@
     <md-toolbar md-theme="{{themePrimary}}" class="md-whiteframe-z1" layout="column">
         <div md-theme="{{themePrimaryButtons}}" class="md-toolbar-tools" layout="row" layout-align="start center"
             style="padding: 0">
-            <span style="margin-left: 8px" flex>Report Parameters</span>
+            <span style="margin-left: 8px" flex>Report Duration - {{vm.reportTimeWindowSecondsDurationReadable}} hours</span>
             <div layout="row" layout-align="start center" style="margin: 0 4px; font-size: 14px;">
                 <div layout="row" layout-align="center center" style="min-width: 180px;">
                     <md-input-container flex md-no-float style="height: 36px; max-width: 135px; margin: 0; padding: 0;" title="Start Date 'yyyy-MM-dd HH:mm:ss'">

--- a/app/reports/utilisation-report.html
+++ b/app/reports/utilisation-report.html
@@ -1,0 +1,90 @@
+<div flex style="padding: 16px; min-width: 600px" ng-controller="UtilisationReportCtrl as vm" layout="row">
+    <div flex layout="column" ng-click="vm.showEndDatePicker = false; vm.showDawtePicker = false;"
+        style="cursor: inherit">
+        <md-toolbar md-theme="{{themePrimary}}" class="md-whiteframe-z1" layout="column">
+            <div md-theme="{{themePrimaryButtons}}" class="md-toolbar-tools" layout="row" layout-align="start center" style="padding: 0">
+                <span style="margin-left: 8px" flex>Report Parameters</span>
+                <input class="fade-in search-input-box" style="width: 200px; max-width: 200px" type="search"
+                       ng-model-options="{ debounce: 300 }" ng-model="vm.searchInputText" placeholder="Filter items..."/>
+                <div layout="row" layout-align="start center" style="margin: 0 4px; font-size: 14px;">
+                    <div layout="row" layout-align="center center" style="min-width: 180px;">
+                        <md-input-container flex md-no-float style="height: 36px; max-width: 135px; margin: 0; padding: 0;" title="Start Date 'yyyy-MM-dd HH:mm:ss'">
+                            <input flex type="text" style="color: white" title="Start Date 'yyyy-MM-dd HH:mm:ss'"
+                                   data-ng-model="vm.startDatetimeReadable" placeholder="Start Date"/>
+                        </md-input-container>
+                        <span></span>
+                        <md-button class="md-icon-button" style="margin-left: 0; margin-top: 3px; width: 40px; height: 40px;"
+                                   ng-click="vm.showDatePicker = !vm.showDatePicker; vm.showEndDatePicker = false; $event.stopPropagation()">
+                            <md-icon class="fa" md-font-icon="fa-calendar"></md-icon>
+                        </md-button>
+
+                        <datetimepicker id="datePickerMenu" class="datepickerMenu md-whiteframe-z3" ng-init="vm.showDatePicker = false"
+                            style="position: absolute; right: 500px; top: 40px; color: #333333" ng-show="vm.showDatePicker"
+                            data-ng-model="vm.startTime" ng-keypress="vm.showDatePicker = false" ng-click="$event.stopPropagation()"
+                            data-on-set-time="vm.showDatePicker = false; vm.onStartTimeSet(vm.startTime)"></datetimepicker>
+                    </div>
+                    <div layout="row" layout-align="center center" style="min-width: 180px">
+                        <md-input-container flex md-no-float style="height: 36px; max-width: 135px; margin: 0; padding: 0;">
+                            <input flex type="text" style="color: white"
+                                   data-ng-model="vm.endDatetimeReadable" placeholder="End Date"
+                                   title="End Date 'yyyy-MM-dd HH:mm:ss'"/>
+                        </md-input-container>
+                        <span></span>
+                        <md-button class="md-icon-button" style="margin-left: 0;width: 40px; height: 40px;"
+                                   ng-click="vm.showEndDatePicker = !vm.showEndDatePicker; vm.showDatePicker = false; $event.stopPropagation()">
+                            <md-icon class="fa" md-font-icon="fa-calendar"></md-icon>
+                        </md-button>
+                        <datetimepicker id="datePickerMenu" class="datepickerMenu md-whiteframe-z3" ng-init="vm.showEndDatePicker = false"
+                            style="position: absolute; right: 335px; top: 40px; color: #333333" ng-show="vm.showEndDatePicker"
+                            data-ng-model="vm.endTime" ng-keypress="vm.showEndDatePicker = false" ng-click="$event.stopPropagation()"
+                            data-on-set-time="vm.showEndDatePicker = false; vm.onEndTimeSet(vm.endTime)"></datetimepicker>
+                    </div>
+                    <md-button class="add-tab md-primary md-raised" ng-click="vm.createReport(event)"
+                               style="margin-right: 0;">Create Report
+                    </md-button>
+                    <md-button ng-disabled="vm.reportItems.length === 0 || vm.exportingPdf" class="add-tab md-primary md-raised" ng-click="vm.exportPdf()"
+                               style="margin-right: 0;">{{vm.exportingPdf? 'Exporting PDF...' : 'Export as PDF'}}
+                    </md-button>
+                </div>
+            </div>
+        </md-toolbar>
+        <div flex style="overflow: auto" layout="column" class="md-whiteframe-z1">
+            <div ng-repeat="result in vm.results" layout="row">
+                <span style="min-width: 400px">{{result[0]}}</span>
+                <span flex style="min-width: 200px; overflow: hidden; text-overflow: ellipsis">{{result[1]}}</span>
+                <span style="min-width: 200px">{{vm.momentDuration(result[2])}}</span>
+            </div>
+        </div>
+        <!-- <div layout="column" class="md-whiteframe-z1" style="overflow: auto" ng-show="vm.reportItems.length > 0">
+            <div class="md-list-item-text" style="min-height: 42px; max-height: 42px; padding: 8px; border-bottom: 1px solid currentColor; font-size: 18px; font-weight: bold;" layout="row" flex>
+                <span style="width: 130px; margin: 0 4px">User</span>
+                <span style="width: 125px">Start</span>
+                <span style="width: 125px">End</span>
+                <span flex>Content</span>
+                <span style="margin-right: 32px">Tags</span>
+            </div> -->
+            <!-- <div ng-repeat="userlog in vm.filteredReportUserlogs = (vm.reportUserlogs | regexSearch:vm.userLogsFields:vm.searchInputText | filter:vm.filterByTag) track by $index" ng-click="vm.editUserLog(userlog, $event)" class="user-log-row"> -->
+                <!-- <div layout="row" layout-align="start center" style="position: relative; border-top: 1px solid #d7d7d7" title="{{userlog.content}}">
+                    <i class="userlog-user-name" title="{{userlog.user.name}}">
+                        <b>{{userlog.user.name}}</b>
+                    </i>
+                    <span style="width: 125px; font-size: 12px">
+                        {{userlog.start_time}}
+                    </span>
+                    <span style="width: 125px; font-size: 12px">
+                        {{userlog.end_time}}
+                    </span>
+                    <pre flex ng-class="{'compressed-userlog': !vm.expandEntries}" style="margin: 0; padding: 0; background: transparent; margin-bottom: 8px; min-height: 33px;" ng-bind-html="userlog.content | linkify | toTrustedHtml"></pre>
+                    <div class="tags-list-container" title="{{userlog.tagsListText}}" ng-class="{'tags-list-compressed-container': !vm.expandEntries}">
+                        <i style="font-size: 11px; padding-right: 2px">{{userlog.tagsListText}}</i>
+                    </div>
+                    <span style="min-width: 24px; margin-left: 8px; font-size: 12px">
+                        <span ng-show="userlog.attachment_count>0">({{userlog.attachment_count}}
+                        <span class="fa fa-paperclip"></span>)
+                        </span>
+                    </span>
+                </div> -->
+            <!-- </div> -->
+        <!-- </div> -->
+    </div>
+</div>

--- a/app/reports/utilisation-report.html
+++ b/app/reports/utilisation-report.html
@@ -43,7 +43,99 @@
         </div>
     </md-toolbar>
     <div flex style="overflow: auto" class="md-whiteframe-z1">
-        <div layout="column" ng-show="vm.subarrayReportResults.length > 0" style="margin-bottom: 8px;">
+
+        <div layout="column" style="margin-bottom: 8px;">
+            <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Scheduler Mode</i>
+            <div layout="row">
+                <i class="report-row-column-item">Subarrays</i>
+                <b ng-repeat="subNr in vm.subarrayNrs" class="report-column-value-item">
+                    {{subNr}}
+                </b>
+            </div>
+            <div layout="row">
+                <div layout="column">
+                    <div ng-repeat="key in $root.objectKeys(vm.schedModeDurations)" class="report-row-value-item">
+                        {{key}}
+                    </div>
+                </div>
+                <div layout="column">
+                    <div ng-repeat="key in $root.objectKeys(vm.schedModeDurations)" layout="row">
+                        <div ng-repeat="subNr in $root.objectKeys(vm.schedModeDurations[key]) | orderBy:subNr" class="report-cell-item" title="{{vm.schedModeDurations[key][subNr].duration}}">
+                            {{vm.schedModeDurations[key][subNr].percentageOfTotal}}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div layout="column" style="margin-bottom: 8px;">
+            <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Subarrays</i>
+            <div layout="row">
+                <i class="report-row-column-item">Subarrays</i>
+                <b ng-repeat="subNr in vm.subarrayNrs" class="report-column-value-item">
+                    {{subNr}}
+                </b>
+            </div>
+            <div layout="row">
+                <b class="report-row-value-item">Maintenance</b>
+                <div ng-repeat="subNr in $root.objectKeys(vm.subarrayMaintenanceDurations) | orderBy:subNr" class="report-cell-item" title="{{vm.subarrayMaintenanceDurations[subNr].duration}}">
+                    {{vm.subarrayMaintenanceDurations[subNr].percentageOfTotal}}
+                </div>
+            </div>
+            <div class="report-section-sub-title-div" style="padding-left: 0">
+                <div class="report-row-value-item" style="border: 0">State</div>
+            </div>
+            <div layout="row">
+                <div layout="column">
+                    <div ng-repeat="key in $root.objectKeys(vm.subarrayStateDurations)" class="report-row-value-item">
+                        {{key}}
+                    </div>
+                </div>
+                <div layout="column">
+                    <div ng-repeat="key in $root.objectKeys(vm.subarrayStateDurations)" layout="row">
+                        <div ng-repeat="subNr in $root.objectKeys(vm.subarrayStateDurations[key]) | orderBy:subNr" class="report-cell-item" title="{{vm.subarrayStateDurations[key][subNr].duration}}">
+                            {{vm.subarrayStateDurations[key][subNr].percentageOfTotal}}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="report-section-sub-title-div" style="padding-left: 0">
+                <div class="report-row-value-item" style="border: 0">Band</div>
+            </div>
+            <div layout="row">
+                <div layout="column">
+                    <div ng-repeat="key in $root.objectKeys(vm.subarrayBandDurations)" class="report-row-value-item">
+                        {{key === ''? 'None': key}}
+                    </div>
+                </div>
+                <div layout="column">
+                    <div ng-repeat="key in $root.objectKeys(vm.subarrayBandDurations)" layout="row">
+                        <div ng-repeat="subNr in $root.objectKeys(vm.subarrayBandDurations[key]) | orderBy:subNr" class="report-cell-item" title="{{vm.subarrayBandDurations[key][subNr].duration}}">
+                            {{vm.subarrayBandDurations[key][subNr].percentageOfTotal}}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="report-section-sub-title-div" style="padding-left: 0">
+                <div class="report-row-value-item" style="border: 0">Product</div>
+            </div>
+            <div layout="row">
+                <div layout="column">
+                    <div ng-repeat="key in $root.objectKeys(vm.subarrayProductDurations)" class="report-row-value-item">
+                        {{key === ''? 'None': key}}
+                    </div>
+                </div>
+                <div layout="column">
+                    <div ng-repeat="key in $root.objectKeys(vm.subarrayProductDurations)" layout="row">
+                        <div ng-repeat="subNr in $root.objectKeys(vm.subarrayProductDurations[key]) | orderBy:subNr" class="report-cell-item" title="{{vm.subarrayProductDurations[key][subNr].duration}}">
+                            {{vm.subarrayProductDurations[key][subNr].percentageOfTotal}}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- <div layout="column" ng-show="vm.subarrayReportResults.length > 0" style="margin-bottom: 8px;">
             <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Subarray Sensors</i>
             <div class="report-section-sub-title-div" layout="row">
                 <span style="width: 300px">Sensor</span>
@@ -60,7 +152,7 @@
                     <span style="width: 100px; text-align: right; margin-left: 16px">{{item.percentageOfTotal}}</span>
                 </div>
             </div>
-        </div>
+        </div> -->
         <div layout="column" ng-show="vm.receptorReportResults.length > 0" style="margin-bottom: 8px;">
             <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Resource Utilisation</i>
             <div layout="column" ng-repeat="subarray in $root.objectKeys(vm.poolResourcesAssignedToSubarraysDurations) | orderBy:subarray track by $index">
@@ -114,7 +206,7 @@
                     <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesMaintenanceDurations[key].percentageOfTotal}}</span>
                 </div>
             </div>
-            <div layout="column" ng-show="vm.interlockReceptorReportResults.length > 0" style="margin-bottom: 8px;">
+            <!-- <div layout="column" ng-show="vm.interlockReceptorReportResults.length > 0" style="margin-bottom: 8px;">
                 <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Receptor Modes</i>
                 <div class="report-section-sub-title-div" layout="row">
                     <span style="width: 300px">Sensor</span>
@@ -131,7 +223,7 @@
                         <span style="width: 100px; text-align: right; margin-left: 16px">{{item.percentageOfTotal}}</span>
                     </div>
                 </div>
-            </div>
+            </div> -->
         </div>
         <div layout="column" ng-show="vm.interlockReceptorReportResults.length > 0" style="margin-bottom: 8px;">
             <i style="font-size: 22px; min-height: 42px" class="report-section-title-div">Interlock/Windstow</i>

--- a/app/reports/utilisation-report.html
+++ b/app/reports/utilisation-report.html
@@ -4,8 +4,6 @@
             <div md-theme="{{themePrimaryButtons}}" class="md-toolbar-tools" layout="row" layout-align="start center"
                 style="padding: 0">
                 <!-- <span style="margin-left: 8px" flex>Report Parameters</span> -->
-                <input class="fade-in search-input-box" style="margin-left: 8px; width: 200px; max-width: 200px" type="search" ng-model-options="{ debounce: 300 }"
-                    ng-model="vm.searchInputText" placeholder="Filter items..." />
                 <div layout="row" layout-align="start center" style="margin: 0 4px; font-size: 14px;">
                     <div layout="row" layout-align="center center" style="min-width: 180px;">
                         <md-input-container flex md-no-float style="height: 36px; max-width: 135px; margin: 0; padding: 0;" title="Start Date 'yyyy-MM-dd HH:mm:ss'">
@@ -47,15 +45,16 @@
                 </div>
             </div>
         </md-toolbar>
-        <div flex layout="column" class="md-whiteframe-z1" ng-show="vm.subarrayReportResults.length > 0">
-            <div class="md-whiteframe-z1" style="min-height: 42px; max-height: 42px; padding: 8px; font-size: 18px; font-weight: bold;" layout="row">
+        <div layout="column" class="md-whiteframe-z1" ng-show="vm.subarrayReportResults.length > 0">
+            <span style="font-size: 22px" class="report-section-title-div">Subarray Section</span>
+            <div class="report-section-title-div" layout="row">
                 <span style="width: 300px">Sensor</span>
                 <span style="width: 125px" flex>Value</span>
                 <span style="width: 80px; text-align: right; margin-left: 16px">Duration</span>
                 <span style="width: 100px; text-align: right; margin-left: 16px">% of Total</span>
             </div>
             <div flex style="overflow: auto" layout="column">
-                <div ng-repeat="item in vm.subarrayReportResults | regexSearch:vm.reportFields:vm.searchInputText track by $index"
+                <div ng-repeat="item in vm.subarrayReportResults track by $index"
                     layout="row" class="report-item text-overflow-ellipsis">
                     <span class="fixed-width-300" title="{{item.sensorName}}">{{item.sensorName}}</span>
                     <span flex style="min-width: 200px" title="{{item.value}}">{{item.value}}</span>
@@ -64,70 +63,96 @@
                 </div>
             </div>
         </div>
-        <div layout="column" class="md-whiteframe-z1" ng-repeat="subarray in $root.objectKeys(vm.poolResourcesAssignedToSubarraysDurations) track by $index">
-            <div class="md-whiteframe-z1" style="min-height: 42px; max-height: 42px; padding: 8px; font-size: 18px; font-weight: bold;" layout="row">
-                <span style="width: 300px">Resources assigned to {{subarray}}</span>
+        <div layout="column" ng-show="vm.receptorReportResults.length > 0" class="md-whiteframe-z1" style="margin-bottom: 8px">
+            <span style="font-size: 22px" class="report-section-title-div">Resources Section</span>
+            <div layout="column" ng-repeat="subarray in $root.objectKeys(vm.poolResourcesAssignedToSubarraysDurations) track by $index">
+                <div class="report-section-title-div" layout="row">
+                    <span flex>Assigned to {{subarray}}</span>
+                    <span ng-show="$index === 0" style="width: 80px; text-align: right; margin-left: 16px">Duration</span>
+                    <span ng-show="$index === 0" style="width: 100px; text-align: right; margin-left: 16px">% of Total</span>
+                </div>
+                <div layout="column">
+                    <div ng-repeat="key in $root.objectKeys(vm.poolResourcesAssignedToSubarraysDurations[subarray]) | orderBy:key"
+                        layout="row" class="report-item text-overflow-ellipsis">
+                        <span flex>{{key}}</span>
+                        <!-- <span flex style="min-width: 200px">{{vm.poolResourcesAssignedToSubarraysDurations[subarray][key].value}}</span> -->
+                        <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesAssignedToSubarraysDurations[subarray][key].duration}}</span>
+                        <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesAssignedToSubarraysDurations[subarray][key].percentageOfTotal}}</span>
+                    </div>
+                    <div class="report-item" ng-show="$root.objectKeys(vm.poolResourcesAssignedToSubarraysDurations[subarray]).length === 0">
+                        <i>None</i>
+                    </div>
+                </div>
+
+            </div>
+            <!-- <div class="md-whiteframe-z1" style="min-height: 42px; max-height: 42px; padding: 8px; font-size: 18px; font-weight: bold;" layout="row">
+                <span style="width: 300px">Resources assigned to a subarray</span>
+                <span style="width: 125px" flex>Value</span>
+                <span style="width: 80px; text-align: right; margin-left: 16px">Duration</span>
+                <span style="width: 100px; text-align: right; margin-left: 16px">% of Total</span>
             </div>
             <div layout="column">
-                <div ng-repeat="key in $root.objectKeys(vm.poolResourcesAssignedToSubarraysDurations[subarray]) | orderBy:key"
+                <div ng-repeat="key in $root.objectKeys(vm.poolResourcesAssignedDurations)"
                     layout="row" class="report-item text-overflow-ellipsis">
                     <span class="fixed-width-300" title="{{key}}">{{key}}</span>
-                    <span flex style="min-width: 200px">{{vm.poolResourcesAssignedToSubarraysDurations[subarray][key].value}}</span>
-                    <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesAssignedToSubarraysDurations[subarray][key].duration}}</span>
-                    <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesAssignedToSubarraysDurations[subarray][key].percentageOfTotal}}</span>
+                    <span flex style="min-width: 200px">{{vm.poolResourcesAssignedDurations[key].value}}</span>
+                    <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesAssignedDurations[key].duration}}</span>
+                    <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesAssignedDurations[key].percentageOfTotal}}</span>
+                </div>
+            </div> -->
+            <div class="report-section-title-div" layout="row">
+                <span flex>Free</span>
+            </div>
+            <div layout="column">
+                <div ng-repeat="key in $root.objectKeys(vm.poolResourcesFreeDurations)"
+                    layout="row" class="report-item text-overflow-ellipsis">
+                    <span flex>{{key}}</span>
+                    <!-- <span flex style="min-width: 200px">{{vm.poolResourcesFreeDurations[key].value}}</span> -->
+                    <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesFreeDurations[key].duration}}</span>
+                    <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesFreeDurations[key].percentageOfTotal}}</span>
                 </div>
             </div>
-
-        </div>
-        <!-- <div class="md-whiteframe-z1" style="min-height: 42px; max-height: 42px; padding: 8px; font-size: 18px; font-weight: bold;" layout="row">
-            <span style="width: 300px">Resources assigned to a subarray</span>
-            <span style="width: 125px" flex>Value</span>
-            <span style="width: 80px; text-align: right; margin-left: 16px">Duration</span>
-            <span style="width: 100px; text-align: right; margin-left: 16px">% of Total</span>
-        </div>
-        <div layout="column">
-            <div ng-repeat="key in $root.objectKeys(vm.poolResourcesAssignedDurations)"
-                layout="row" class="report-item text-overflow-ellipsis">
-                <span class="fixed-width-300" title="{{key}}">{{key}}</span>
-                <span flex style="min-width: 200px">{{vm.poolResourcesAssignedDurations[key].value}}</span>
-                <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesAssignedDurations[key].duration}}</span>
-                <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesAssignedDurations[key].percentageOfTotal}}</span>
+            <div class="red-color report-section-title-div" layout="row">
+                <span flex>Faulty</span>
             </div>
-        </div> -->
-        <div class="md-whiteframe-z1 report-section-title-div">
-            Free Resources
-        </div>
-        <div layout="column">
-            <div ng-repeat="key in $root.objectKeys(vm.poolResourcesFreeDurations)"
-                layout="row" class="report-item text-overflow-ellipsis">
-                <span class="fixed-width-300" title="{{key}}">{{key}}</span>
-                <span flex style="min-width: 200px">{{vm.poolResourcesFreeDurations[key].value}}</span>
-                <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesFreeDurations[key].duration}}</span>
-                <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesFreeDurations[key].percentageOfTotal}}</span>
+            <div layout="column">
+                <div ng-repeat="key in $root.objectKeys(vm.poolResourcesFaultyDurations)"
+                    layout="row" class="report-item text-overflow-ellipsis">
+                    <span flex>{{key}}</span>
+                    <!-- <span flex style="min-width: 200px">{{vm.poolResourcesFaultyDurations[key].value}}</span> -->
+                    <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesFaultyDurations[key].duration}}</span>
+                    <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesFaultyDurations[key].percentageOfTotal}}</span>
+                </div>
+            </div>
+            <div class="maintenance-color report-section-title-div" layout="row">
+                <span flex>In Maintenance</span>
+            </div>
+            <div layout="column">
+                <div ng-repeat="key in $root.objectKeys(vm.poolResourcesMaintenanceDurations)"
+                    layout="row" class="report-item text-overflow-ellipsis">
+                    <span flex>{{key}}</span>
+                    <!-- <span flex style="min-width: 200px">{{vm.poolResourcesMaintenanceDurations[key].value}}</span> -->
+                    <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesMaintenanceDurations[key].duration}}</span>
+                    <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesMaintenanceDurations[key].percentageOfTotal}}</span>
+                </div>
             </div>
         </div>
-        <div class="md-whiteframe-z1 report-section-title-div">
-            Faulty Resources
-        </div>
-        <div layout="column">
-            <div ng-repeat="key in $root.objectKeys(vm.poolResourcesFaultyDurations)"
-                layout="row" class="report-item text-overflow-ellipsis">
-                <span class="fixed-width-300" title="{{key}}">{{key}}</span>
-                <span flex style="min-width: 200px">{{vm.poolResourcesFaultyDurations[key].value}}</span>
-                <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesFaultyDurations[key].duration}}</span>
-                <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesFaultyDurations[key].percentageOfTotal}}</span>
+        <div layout="column" class="md-whiteframe-z1" ng-show="vm.windstowReceptorReportResults.length > 0">
+            <span style="font-size: 22px" class="report-section-title-div">Windstow Section</span>
+            <div class="report-section-title-div" layout="row">
+                <span style="width: 300px">Sensor</span>
+                <span style="width: 125px" flex>Value</span>
+                <span style="width: 80px; text-align: right; margin-left: 16px">Duration</span>
+                <span style="width: 100px; text-align: right; margin-left: 16px">% of Total</span>
             </div>
-        </div>
-        <div class="md-whiteframe-z1 report-section-title-div">
-            In Maintenance Resources
-        </div>
-        <div layout="column">
-            <div ng-repeat="key in $root.objectKeys(vm.poolResourcesMaintenanceDurations)"
-                layout="row" class="report-item text-overflow-ellipsis">
-                <span class="fixed-width-300" title="{{key}}">{{key}}</span>
-                <span flex style="min-width: 200px">{{vm.poolResourcesMaintenanceDurations[key].value}}</span>
-                <span style="width: 80px; text-align: right; margin-left: 16px">{{vm.poolResourcesMaintenanceDurations[key].duration}}</span>
-                <span style="width: 100px; text-align: right; margin-left: 16px">{{vm.poolResourcesMaintenanceDurations[key].percentageOfTotal}}</span>
+            <div flex style="overflow: auto" layout="column">
+                <div ng-repeat="item in vm.windstowReceptorReportResults track by $index"
+                    layout="row" class="report-item text-overflow-ellipsis">
+                    <span class="fixed-width-300" title="{{item.sensorName}}">{{item.sensorName}}</span>
+                    <span flex style="min-width: 200px" title="{{item.value}}">{{item.value}}</span>
+                    <span style="width: 80px; text-align: right; margin-left: 16px">{{item.duration}}</span>
+                    <span style="width: 100px; text-align: right; margin-left: 16px">{{item.percentageOfTotal}}</span>
+                </div>
             </div>
         </div>
     </div>

--- a/app/reports/utilisation-report.js
+++ b/app/reports/utilisation-report.js
@@ -308,9 +308,10 @@
                             if (reportItem.duration) {
                                 reportItem.percentageOfTotal = vm.percentageOfTotalToString(reportItem.durationSeconds);
                             }
-                            var resources, subarray, i, key;
+                            $log.info(reportItem);
                             if (reportItem.sensorName.search('katpool.pool.resources..|katpool.resources.faulty|katpool.resources.in.maintenance') > -1 && reportItem.value.length > 0) {
-                                resources = reportItem.value.split(',');
+                                var resources = reportItem.value.split(',');
+                                var key;
                                 if (reportItem.sensorName.endsWith('faulty')) {
                                     key = 'faulty';
                                 } else if (reportItem.sensorName.endsWith('in_maintenance')) {
@@ -318,6 +319,7 @@
                                 } else {
                                     key = _.last(reportItem.sensorName.split('_'));
                                 }
+
                                 resources.forEach(function (resource) {
                                     if (!vm.poolResourcesAssignedDurations[resource]) {
                                         vm.poolResourcesAssignedDurations[resource] = {durationTotalSeconds: 0, percentageTotal: '0%', durationTotal: '0:00:00'};
@@ -333,7 +335,13 @@
                                     }
 
                                     if (!vm.poolResourcesAssignedDurations[resource][key].value) {
-                                        vm.poolResourcesAssignedDurations[resource][key] = reportItem;
+                                        vm.poolResourcesAssignedDurations[resource][key] = {
+                                            duration: reportItem.duration,
+                                            durationSeconds: reportItem.durationSeconds,
+                                            percentageOfTotal: reportItem.percentageOfTotal,
+                                            sensorName: reportItem.sensorName,
+                                            value: resource
+                                        };
                                     } else {
                                         var existingResourceItem = vm.poolResourcesAssignedDurations[resource][key];
                                         existingResourceItem.durationSeconds += reportItem.durationSeconds;

--- a/app/reports/utilisation-report.js
+++ b/app/reports/utilisation-report.js
@@ -81,109 +81,173 @@
                 pdf.setFontSize(20);
                 pdf.text('Utilisation Report - ' + exportTime + ' (UTC)', 20, 25);
                 pdf.setFontSize(12);
+
+                pdf.text('From: ' + vm.startDatetimeReadable + '\tTo: ' + vm.endDatetimeReadable + '\t\t(Report Duration: ' + vm.reportTimeWindowSecondsDurationReadable + ' hours)', 20, 45);
+
+                var schedColumns = [
+                    {title: "", dataKey: "value"},
+                    {title: "1", dataKey: "percentageOfTotal_1"},
+                    {title: "2", dataKey: "percentageOfTotal_2"},
+                    {title: "3", dataKey: "percentageOfTotal_3"},
+                    {title: "4", dataKey: "percentageOfTotal_4"}
+                ];
+                var schedModeKeys = Object.keys(vm.schedModeDurations);
+                var rows = [];
+                schedModeKeys.forEach(function (key) {
+                    rows.push({
+                        value: key,
+                        percentageOfTotal_1: vm.schedModeDurations[key]['1'].percentageOfTotal,
+                        percentageOfTotal_2: vm.schedModeDurations[key]['2'].percentageOfTotal,
+                        percentageOfTotal_3: vm.schedModeDurations[key]['3'].percentageOfTotal,
+                        percentageOfTotal_4: vm.schedModeDurations[key]['4'].percentageOfTotal
+                    });
+                });
+
+                pdf.setFontSize(20);
+                pdf.text('Scheduler Mode', 20, 80);
                 pdf.setFontSize(12);
-                pdf.text(('From: ' + vm.startDatetimeReadable + '     To: ' + vm.endDatetimeReadable), 20, 45);
+
+                pdf.autoTable(schedColumns, rows, {
+                    startY: 95,
+                    theme: 'striped',
+                    margin: {top: 8, bottom: 8}});
+
+                var subarrayStateKeys = Object.keys(vm.subarrayStateDurations);
+                rows = [];
+                schedColumns[0].title = "";
+                subarrayStateKeys.forEach(function (key) {
+                    rows.push({
+                        value: key,
+                        percentageOfTotal_1: vm.subarrayStateDurations[key]['1'].percentageOfTotal,
+                        percentageOfTotal_2: vm.subarrayStateDurations[key]['2'].percentageOfTotal,
+                        percentageOfTotal_3: vm.subarrayStateDurations[key]['3'].percentageOfTotal,
+                        percentageOfTotal_4: vm.subarrayStateDurations[key]['4'].percentageOfTotal
+                    });
+                });
+                pdf.setFontSize(20);
+                pdf.text('Subarray State', 20, pdf.autoTableEndPosY() + 45);
+                pdf.setFontSize(12);
+
+                pdf.autoTable(schedColumns, rows, {
+                    startY: pdf.autoTableEndPosY() + 60,
+                    theme: 'striped',
+                    margin: {top: 8, bottom: 8}});
+
+                schedColumns[0].title = "";
+                var subarrayBandKeys = Object.keys(vm.subarrayBandDurations);
+                rows = [];
+                subarrayBandKeys.forEach(function (key) {
+                    rows.push({
+                        value: key !== ""? key: "None",
+                        percentageOfTotal_1: vm.subarrayBandDurations[key]['1'].percentageOfTotal,
+                        percentageOfTotal_2: vm.subarrayBandDurations[key]['2'].percentageOfTotal,
+                        percentageOfTotal_3: vm.subarrayBandDurations[key]['3'].percentageOfTotal,
+                        percentageOfTotal_4: vm.subarrayBandDurations[key]['4'].percentageOfTotal
+                    });
+                });
+
+                pdf.setFontSize(20);
+                pdf.text('Subarray Bands', 20, pdf.autoTableEndPosY() + 45);
+                pdf.setFontSize(12);
+
+                pdf.autoTable(schedColumns, rows, {
+                    startY: pdf.autoTableEndPosY() + 60,
+                    theme: 'striped',
+                    margin: {top: 8, bottom: 8}});
+
+                schedColumns[0].title = "";
+                var subarrayProductKeys = Object.keys(vm.subarrayProductDurations);
+                rows = [];
+                subarrayProductKeys.forEach(function (key) {
+                    rows.push({
+                        value: key !== ""? key: "None",
+                        percentageOfTotal_1: vm.subarrayProductDurations[key]['1'].percentageOfTotal,
+                        percentageOfTotal_2: vm.subarrayProductDurations[key]['2'].percentageOfTotal,
+                        percentageOfTotal_3: vm.subarrayProductDurations[key]['3'].percentageOfTotal,
+                        percentageOfTotal_4: vm.subarrayProductDurations[key]['4'].percentageOfTotal
+                    });
+                });
+
+                pdf.setFontSize(20);
+                pdf.text('Subarray Products', 20, pdf.autoTableEndPosY() + 45);
+                pdf.setFontSize(12);
+
+                pdf.autoTable(schedColumns, rows, {
+                    startY: pdf.autoTableEndPosY() + 60,
+                    theme: 'striped',
+                    margin: {top: 8, bottom: 8}});
+
+                var poolResourcesKeys = Object.keys(vm.poolResourcesAssignedDurations).sort();
+                rows = [];
+                poolResourcesKeys.forEach(function (key) {
+                    rows.push({
+                        resource: key,
+                        durationTotal: vm.poolResourcesAssignedDurations[key].durationTotal,
+                        percentageTotal: vm.poolResourcesAssignedDurations[key].percentageTotal,
+                        faulty: vm.poolResourcesAssignedDurations[key].faulty.percentageOfTotal,
+                        in_maintenance: vm.poolResourcesAssignedDurations[key].in_maintenance.percentageOfTotal,
+                        percentageOfTotal_1: vm.poolResourcesAssignedDurations[key]['1'].percentageOfTotal,
+                        percentageOfTotal_2: vm.poolResourcesAssignedDurations[key]['2'].percentageOfTotal,
+                        percentageOfTotal_3: vm.poolResourcesAssignedDurations[key]['3'].percentageOfTotal,
+                        percentageOfTotal_4: vm.poolResourcesAssignedDurations[key]['4'].percentageOfTotal
+                    });
+                });
+
+                var resourceColumns = [
+                    {title: "Resource", dataKey: "resource"},
+                    {title: "Total Duration", dataKey: "durationTotal"},
+                    {title: "Total %", dataKey: "percentageTotal"},
+                    {title: "1", dataKey: "percentageOfTotal_1"},
+                    {title: "2", dataKey: "percentageOfTotal_2"},
+                    {title: "3", dataKey: "percentageOfTotal_3"},
+                    {title: "4", dataKey: "percentageOfTotal_4"},
+                    {title: "faulty", dataKey: "faulty"},
+                    {title: "in_maintenance", dataKey: "in_maintenance"}
+                ];
 
                 pdf.setFontSize(20);
                 pdf.text('Resource Utilisation', 20, pdf.autoTableEndPosY() + 45);
+                pdf.setFontSize(12);
 
-                var assignedToSubColumns = [
-                    {title: "Assigned to Subarray ", dataKey: "resourceName"},
-                    {title: "Duration", dataKey: "duration"},
-                    {title: "% of Total", dataKey: "percentageOfTotal"}
-                ];
-
-
-                assignedToSubColumns[0].title = "Free";
-                var assignedToFree = [];
-                var resourcesAssignedToFree = Object.keys(vm.poolResourcesFreeDurations);
-                resourcesAssignedToFree.forEach(function (key) {
-                    assignedToFree.push(vm.poolResourcesFreeDurations[key]);
-                });
-
-                if (assignedToFree.length > 0) {
-                    pdf.autoTable(assignedToSubColumns, assignedToFree, {
-                        startY: pdf.autoTableEndPosY() + 8,
-                        theme: 'striped',
-                        margin: {top: 8, bottom: 8},
-                        columnStyles: {
-                            sensorName: {columnWidth: 200, overflow: 'linebreak'},
-                            value: {},
-                            duration: {columnWidth: 80},
-                            percentageOfTotal: {columnWidth: 80}}});
-                }
-
-                assignedToSubColumns[0].title = "Faulty";
-                var assignedToFaulty = [];
-                var resourcesAssignedToFaulty = Object.keys(vm.poolResourcesFaultyDurations);
-                resourcesAssignedToFaulty.forEach(function (key) {
-                    assignedToFaulty.push(vm.poolResourcesFaultyDurations[key]);
-                });
-
-                if (assignedToFaulty.length > 0) {
-                    pdf.autoTable(assignedToSubColumns, assignedToFaulty, {
-                        startY: pdf.autoTableEndPosY() + 8,
-                        theme: 'striped',
-                        margin: {top: 8, bottom: 8},
-                        columnStyles: {
-                            sensorName: {columnWidth: 200, overflow: 'linebreak'},
-                            value: {},
-                            duration: {columnWidth: 80},
-                            percentageOfTotal: {columnWidth: 80}}});
-                }
-
-                assignedToSubColumns[0].title = "In Maintenance";
-                var assignedToInMaintenance = [];
-                var resourcesAssignedToInMaintenance = Object.keys(vm.poolResourcesMaintenanceDurations);
-                resourcesAssignedToInMaintenance.forEach(function (key) {
-                    assignedToInMaintenance.push(vm.poolResourcesMaintenanceDurations[key]);
-                });
-
-                if (assignedToInMaintenance.length > 0) {
-                    pdf.autoTable(assignedToSubColumns, assignedToInMaintenance, {
-                        startY: pdf.autoTableEndPosY() + 8,
-                        theme: 'striped',
-                        margin: {top: 8, bottom: 8},
-                        columnStyles: {
-                            sensorName: {columnWidth: 200, overflow: 'linebreak'},
-                            value: {},
-                            duration: {columnWidth: 80},
-                            percentageOfTotal: {columnWidth: 80}}});
-                }
-
-                pdf.text('Interlock / Windstow', 20, pdf.autoTableEndPosY() + 45);
-                pdf.autoTable(sensorColumns, vm.interlockReceptorReportResults, {
+                pdf.autoTable(resourceColumns, rows, {
                     startY: pdf.autoTableEndPosY() + 60,
                     theme: 'striped',
-                    margin: {top: 8, bottom: 8},
-                    columnStyles: {
-                        sensorName: {columnWidth: 200, overflow: 'linebreak'},
-                        value: {},
-                        duration: {columnWidth: 80},
-                        percentageOfTotal: {columnWidth: 80}}});
+                    margin: {top: 8, bottom: 8}});
 
-                pdf.text('Active Schedule Blocks', 20, pdf.autoTableEndPosY() + 45);
-                pdf.autoTable(sensorColumns, vm.scheduleReportResults, {
+                var systemStateColumns = [{title: "Interlock State", dataKey: "rowName"}];
+                rows = [{rowName: 'Percentage'}, {rowName: 'Duration'}];
+                Object.keys(vm.interlockReceptorReportResults).forEach(function (key) {
+                    if (!_.find(systemStateColumns, {title: key})) {
+                        systemStateColumns.push({title: key, dataKey: key});
+                    }
+                    rows[0][key] = vm.interlockReceptorReportResults[key].percentageOfTotal;
+                    rows[1][key] = vm.interlockReceptorReportResults[key].duration;
+                });
+
+                pdf.setFontSize(20);
+                pdf.text('System State', 20, pdf.autoTableEndPosY() + 45);
+                pdf.setFontSize(12);
+
+                pdf.autoTable(systemStateColumns, rows, {
                     startY: pdf.autoTableEndPosY() + 60,
                     theme: 'striped',
-                    margin: {top: 8, bottom: 8},
-                    columnStyles: {
-                        sensorName: {columnWidth: 200, overflow: 'linebreak'},
-                        value: {},
-                        duration: {columnWidth: 80},
-                        percentageOfTotal: {columnWidth: 80}}});
+                    margin: {top: 8, bottom: 8}});
 
                 var sbColumns = [
                     {title: "Id Code", dataKey: "id_code"},
                     {title: "Owner", dataKey: "owner"},
                     {title: "Description", dataKey: "description"},
+                    {title: "Subarray", dataKey: "sub_nr"},
                     {title: "State", dataKey: "state"},
                     {title: "Outcome", dataKey: "outcome"},
                     {title: "Duration", dataKey: "duration"},
                     {title: "% of Total", dataKey: "percentageOfTotal"},
                 ];
 
+                pdf.setFontSize(20);
                 pdf.text('Active Schedule Block Details', 20, pdf.autoTableEndPosY() + 45);
+                pdf.setFontSize(12);
+
                 pdf.autoTable(sbColumns, vm.SBDetails, {
                     startY: pdf.autoTableEndPosY() + 60,
                     theme: 'striped',
@@ -192,6 +256,7 @@
                         id_code: {columnWidth: 85},
                         owner: {columnWidth: 85},
                         description: {overflow: 'linebreak'},
+                        subarray: {columnWidth: 65},
                         state: {columnWidth: 85},
                         outcome: {columnWidth: 85},
                         duration: {columnWidth: 80},

--- a/app/reports/utilisation-report.js
+++ b/app/reports/utilisation-report.js
@@ -19,14 +19,15 @@
             vm.startDatetimeReadable = moment(vm.startTime.getTime()).format(DATETIME_FORMAT);
             vm.endDatetimeReadable = moment(vm.endTime.getTime()).format(DATETIME_FORMAT);
             vm.reportTimeWindowMSDuration = 0;
-            vm.creatingReport = false;
-            vm.subarrayReportSensorsRegex = "subarray...state|subarray...maintenance|subarray...product|subarray...band|sched.mode..";
-            vm.receptorsReportSensorsRegex = "^(m0..|ant.).windstow.active|pool.resources.free|subarray...pool.resources|resources.faulty|resources.in.maintenance";
+            vm.creatingReceptorReport = false;
+            vm.creatingSubarrayReport = false;
+            vm.subarrayReportSensorsRegex = "sched.active.schedule..|subarray...state|subarray...maintenance|subarray...product|subarray...band|sched.mode..";
+            vm.receptorsReportSensorsRegex = "^(m0..|ant.).windstow.active|pool.resources.free|subarray...pool.resources|resources.faulty|resources.in.maintenance|sys.interlock.state";
             vm.poolResourcesAssignedDurations = {};
             vm.poolResourcesFreeDurations = {};
             vm.poolResourcesFaultyDurations = {};
             vm.poolResourcesMaintenanceDurations = {};
-            vm.windstowReceptorReportResults = [];
+            vm.interlockReceptorReportResults = [];
 
             //TODO probably get from config
             vm.poolResourcesAssignedToSubarraysDurations = {
@@ -54,7 +55,7 @@
                 vm.poolResourcesFreeDurations = {};
                 vm.poolResourcesFaultyDurations = {};
                 vm.poolResourcesMaintenanceDurations = {};
-                vm.windstowReceptorReportResults = [];
+                vm.interlockReceptorReportResults = [];
                 vm.poolResourcesAssignedToSubarraysDurations = {
                     subarray_1: {},
                     subarray_2: {},
@@ -71,69 +72,75 @@
                 vm.endDatetimeReadable = moment(vm.endTime.getTime()).format(DATETIME_FORMAT);
             };
 
-            // vm.exportPdf = function(){
-            //     vm.exportingPdf = true;
-            //     var pdf = new jsPDF('l', 'pt');
-            //     var exportTime = moment.utc().format(DATETIME_FORMAT);
-            //     var query = "?start_time=" + vm.startDatetimeReadable + "&end_time=" + vm.endDatetimeReadable;
-            //
-            //     vm.filteredReportUserlogs.forEach(function (userlog) {
-            //         userlog.userName = userlog.user.name;
-            //         var tagNames = [];
-            //         userlog.tags.forEach(function (tag) {
-            //             tagNames.push(tag.name);
-            //         });
-            //         userlog.tag_list = tagNames.join(',');
-            //     });
-            //
-            //     var columns = [
-            //         {title: "User", dataKey: "userName"},
-            //         {title: "Start", dataKey: "start_time"},
-            //         {title: "End", dataKey: "end_time"},
-            //         {title: "Content", dataKey: "content"},
-            //         {title: "Tags", dataKey: "tag_list"}
-            //     ];
-            //
-            //     pdf.setFontSize(20);
-            //     pdf.text('Userlog Report - ' + exportTime + ' (UTC)', 20, 25);
-            //     pdf.setFontSize(12);
-            //     pdf.setFontSize(12);
-            //     pdf.text(('From: ' + vm.startDatetimeReadable + '     To: ' + vm.endDatetimeReadable), 20, 45);
-            //
-            //     pdf.autoTable(columns, vm.filteredReportUserlogs, {
-            //         startY: 55,
-            //         theme: 'striped',
-            //         margin: {top: 8, bottom: 8},
-            //         columnStyles: {
-            //             userName: {columnWidth: 80, overflow: 'linebreak'},
-            //             start_time: {columnWidth: 120},
-            //             end_time: {columnWidth: 120},
-            //             content: {overflow: 'linebreak'},
-            //             tag_list: {overflow: 'linebreak'}}});
-            //
-            //     if (vm.includeActivityLogs) {
-            //         columns = [{title: "System Activity Logs", key: "msg"}];
-            //
-            //         UserLogService.queryActivityLogs(query).then(
-            //             function (result) {
-            //                 pdf.autoTable(columns, result.data, {
-            //                     startY: pdf.autoTableEndPosY() + 50,
-            //                     theme: 'striped',
-            //                     margin: {top: 8, bottom: 8}});
-            //                 pdf.save('Userlog_Report_' + exportTime.replace(/ /g, '.') + '.pdf');
-            //                 vm.exportingPdf = false;
-            //             }, function (error) {
-            //                 $log.error(error);
-            //                 vm.exportingPdf = false;
-            //             });
-            //     } else {
-            //         pdf.save('Userlog_Report_' + exportTime.replace(/ /g, '.') + '.pdf');
-            //         vm.exportingPdf = false;
-            //     }
-            // };
+            vm.exportPdf = function(){
+                alert("UNIMPLEMENTED");
+                // vm.exportingPdf = true;
+                // var pdf = new jsPDF('l', 'pt');
+                // var exportTime = moment.utc().format(DATETIME_FORMAT);
+                // var query = "?start_time=" + vm.startDatetimeReadable + "&end_time=" + vm.endDatetimeReadable;
+                //
+                // vm.filteredReportUserlogs.forEach(function (userlog) {
+                //     userlog.userName = userlog.user.name;
+                //     var tagNames = [];
+                //     userlog.tags.forEach(function (tag) {
+                //         tagNames.push(tag.name);
+                //     });
+                //     userlog.tag_list = tagNames.join(',');
+                // });
+                //
+                // var columns = [
+                //     {title: "User", dataKey: "userName"},
+                //     {title: "Start", dataKey: "start_time"},
+                //     {title: "End", dataKey: "end_time"},
+                //     {title: "Content", dataKey: "content"},
+                //     {title: "Tags", dataKey: "tag_list"}
+                // ];
+                //
+                // pdf.setFontSize(20);
+                // pdf.text('Userlog Report - ' + exportTime + ' (UTC)', 20, 25);
+                // pdf.setFontSize(12);
+                // pdf.setFontSize(12);
+                // pdf.text(('From: ' + vm.startDatetimeReadable + '     To: ' + vm.endDatetimeReadable), 20, 45);
+                //
+                // pdf.autoTable(columns, vm.filteredReportUserlogs, {
+                //     startY: 55,
+                //     theme: 'striped',
+                //     margin: {top: 8, bottom: 8},
+                //     columnStyles: {
+                //         userName: {columnWidth: 80, overflow: 'linebreak'},
+                //         start_time: {columnWidth: 120},
+                //         end_time: {columnWidth: 120},
+                //         content: {overflow: 'linebreak'},
+                //         tag_list: {overflow: 'linebreak'}}});
+                //
+                // if (vm.includeActivityLogs) {
+                //     columns = [{title: "System Activity Logs", key: "msg"}];
+                //
+                //     UserLogService.queryActivityLogs(query).then(
+                //         function (result) {
+                //             pdf.autoTable(columns, result.data, {
+                //                 startY: pdf.autoTableEndPosY() + 50,
+                //                 theme: 'striped',
+                //                 margin: {top: 8, bottom: 8}});
+                //             pdf.save('Userlog_Report_' + exportTime.replace(/ /g, '.') + '.pdf');
+                //             vm.exportingPdf = false;
+                //         }, function (error) {
+                //             $log.error(error);
+                //             vm.exportingPdf = false;
+                //         });
+                // } else {
+                //     pdf.save('Userlog_Report_' + exportTime.replace(/ /g, '.') + '.pdf');
+                //     vm.exportingPdf = false;
+                // }
+            };
+
+            vm.createReport = function () {
+                vm.createSubarraysReport();
+                vm.createReceptorsReport();
+            };
 
             vm.createSubarraysReport = function () {
-                vm.creatingReport = true;
+                vm.creatingSubarrayReport = true;
                 $state.go('utilisation-report', {
                         startTime: vm.startDatetimeReadable,
                         endTime: vm.endDatetimeReadable,
@@ -161,16 +168,16 @@
                             vm.subarrayReportResults.push(reportItem);
                         });
                     }
-                    vm.creatingReport = false;
+                    vm.creatingSubarrayReport = false;
                 }, function (result) {
-                    vm.creatingReport = false;
+                    vm.creatingSubarrayReport = false;
                     NotifyService.showSimpleDialog('Error creating report', result.data);
                     $log.error(result);
                 });
             };
 
             vm.createReceptorsReport = function () {
-                vm.creatingReport = true;
+                vm.creatingReceptorReport = true;
                 $state.go('utilisation-report', {
                         startTime: vm.startDatetimeReadable,
                         endTime: vm.endDatetimeReadable,
@@ -180,7 +187,7 @@
                 var startDate = moment(vm.startDatetimeReadable).toDate().getTime();
                 var endDate =  moment(vm.endDatetimeReadable).toDate().getTime();
                 DataService.sampleValueDuration(vm.receptorsReportSensorsRegex, startDate, endDate).then(function (result) {
-                    vm.creatingReport = false;
+                    vm.creatingReceptorReport = false;
                     vm.reportTimeWindowSecondsDuration = Math.abs(endDate - startDate) / 1000;
                     if (result.data) {
                         result.data.forEach(function (item) {
@@ -241,7 +248,9 @@
                                     vm.poolResourcesMaintenanceDurations[resources[i]].durationSeconds += item[2];
                                 }
                             } else if (reportItem.sensorName.search('windstow.active') > -1) {
-                                vm.windstowReceptorReportResults.push(reportItem);
+                                vm.interlockReceptorReportResults.push(reportItem);
+                            } else if (reportItem.sensorName.search('sys.interlock.state') > -1) {
+                                vm.interlockReceptorReportResults.push(reportItem);
                             }
                             vm.receptorReportResults.push(reportItem);
                         });
@@ -282,7 +291,7 @@
                         });
                     }
                 }, function (result) {
-                    vm.creatingReport = false;
+                    vm.creatingReceptorReport = false;
                     NotifyService.showSimpleDialog('Error creating report', result.data);
                     $log.error(result);
                 });

--- a/app/reports/utilisation-report.js
+++ b/app/reports/utilisation-report.js
@@ -1,0 +1,148 @@
+(function () {
+
+    angular.module('katGui')
+        .controller('UtilisationReportCtrl', UtilisationReportCtrl);
+
+        function UtilisationReportCtrl($rootScope, $scope, $localStorage, $filter, DataService,
+                                    $log, $stateParams, NotifyService, $timeout, $state) {
+
+            var vm = this;
+            var DATETIME_FORMAT = 'YYYY-MM-DD HH:mm:ss';
+            vm.startTime = new Date();
+            vm.endTime = vm.startTime;
+            vm.startDatetimeReadable = moment(vm.startTime.getTime()).format('YYYY-MM-DD 00:00:00');
+            vm.endDatetimeReadable = moment(vm.endTime.getTime()).format('YYYY-MM-DD 23:59:59');
+            vm.reportItems = [];
+
+            if ($stateParams.filter) {
+                vm.searchInputText = $stateParams.filter;
+            }
+
+            vm.reportFields = [
+                {label: 'Start Time', value: 'start_time'},
+                {label: 'Name', value: 'user.name'},
+                {label: 'End Time', value: 'end_time'},
+                {label: 'Content', value: 'content'}
+            ];
+
+            vm.onStartTimeSet = function () {
+                vm.startDatetimeReadable = moment(vm.startTime.getTime()).format(DATETIME_FORMAT);
+            };
+
+            vm.onEndTimeSet = function () {
+                vm.endDatetimeReadable = moment(vm.endTime.getTime()).format(DATETIME_FORMAT);
+            };
+
+            // vm.exportPdf = function(){
+            //     vm.exportingPdf = true;
+            //     var pdf = new jsPDF('l', 'pt');
+            //     var exportTime = moment.utc().format(DATETIME_FORMAT);
+            //     var query = "?start_time=" + vm.startDatetimeReadable + "&end_time=" + vm.endDatetimeReadable;
+            //
+            //     vm.filteredReportUserlogs.forEach(function (userlog) {
+            //         userlog.userName = userlog.user.name;
+            //         var tagNames = [];
+            //         userlog.tags.forEach(function (tag) {
+            //             tagNames.push(tag.name);
+            //         });
+            //         userlog.tag_list = tagNames.join(',');
+            //     });
+            //
+            //     var columns = [
+            //         {title: "User", dataKey: "userName"},
+            //         {title: "Start", dataKey: "start_time"},
+            //         {title: "End", dataKey: "end_time"},
+            //         {title: "Content", dataKey: "content"},
+            //         {title: "Tags", dataKey: "tag_list"}
+            //     ];
+            //
+            //     pdf.setFontSize(20);
+            //     pdf.text('Userlog Report - ' + exportTime + ' (UTC)', 20, 25);
+            //     pdf.setFontSize(12);
+            //     pdf.setFontSize(12);
+            //     pdf.text(('From: ' + vm.startDatetimeReadable + '     To: ' + vm.endDatetimeReadable), 20, 45);
+            //
+            //     pdf.autoTable(columns, vm.filteredReportUserlogs, {
+            //         startY: 55,
+            //         theme: 'striped',
+            //         margin: {top: 8, bottom: 8},
+            //         columnStyles: {
+            //             userName: {columnWidth: 80, overflow: 'linebreak'},
+            //             start_time: {columnWidth: 120},
+            //             end_time: {columnWidth: 120},
+            //             content: {overflow: 'linebreak'},
+            //             tag_list: {overflow: 'linebreak'}}});
+            //
+            //     if (vm.includeActivityLogs) {
+            //         columns = [{title: "System Activity Logs", key: "msg"}];
+            //
+            //         UserLogService.queryActivityLogs(query).then(
+            //             function (result) {
+            //                 pdf.autoTable(columns, result.data, {
+            //                     startY: pdf.autoTableEndPosY() + 50,
+            //                     theme: 'striped',
+            //                     margin: {top: 8, bottom: 8}});
+            //                 pdf.save('Userlog_Report_' + exportTime.replace(/ /g, '.') + '.pdf');
+            //                 vm.exportingPdf = false;
+            //             }, function (error) {
+            //                 $log.error(error);
+            //                 vm.exportingPdf = false;
+            //             });
+            //     } else {
+            //         pdf.save('Userlog_Report_' + exportTime.replace(/ /g, '.') + '.pdf');
+            //         vm.exportingPdf = false;
+            //     }
+            // };
+
+            vm.createReport = function () {
+                $state.go('utilisation-report', {
+                        startTime: vm.startDatetimeReadable,
+                        endTime: vm.endDatetimeReadable,
+                        filter: vm.searchInputText},
+                        { notify: false, reload: false });
+                vm.results = [];
+                var startDate = moment(vm.startDatetimeReadable).toDate().getTime();
+                var endDate =  moment(vm.endDatetimeReadable).toDate().getTime();
+                DataService.sampleValueDuration(vm.searchInputText, startDate, endDate).then(function (result) {
+                    $log.info(result);
+                    if (result.data) {
+                        vm.results = result.data;
+                    }
+                });
+            };
+
+            vm.afterInit = function() {
+                $timeout(function () {
+                    var startTimeParam = moment($stateParams.startTime, DATETIME_FORMAT, true);
+                    var endTimeParam = moment($stateParams.startTime, DATETIME_FORMAT, true);
+                    if (startTimeParam.isValid() && endTimeParam.isValid()) {
+                        vm.startTime = startTimeParam.toDate();
+                        vm.endTime = endTimeParam.toDate();
+                        vm.startDatetimeReadable = $stateParams.startTime;
+                        vm.endDatetimeReadable = $stateParams.endTime;
+
+                        // vm.createReport();
+                    } else if ($stateParams.startTime && $stateParams.endTime) {
+                        NotifyService.showSimpleDialog('Invalid Datetime URL Parameters',
+                            'Invalid datetime strings: ' + $stateParams.startTime + ' or ' + $stateParams.endTime + '. Format should be ' + DATETIME_FORMAT);
+                    }
+                }, 1000);
+            };
+
+            if ($rootScope.currentUser) {
+                vm.afterInit();
+            } else {
+                vm.unbindLoginSuccess = $rootScope.$on('loginSuccess', vm.afterInit);
+            }
+
+            vm.momentDuration = function (seconds) {
+                return moment.duration(seconds, 's').humanize();
+            };
+
+            $scope.$on('$destroy', function () {
+                if (vm.unbindLoginSuccess) {
+                    vm.unbindLoginSuccess();
+                }
+            });
+        }
+})();

--- a/app/reports/utilisation-report.js
+++ b/app/reports/utilisation-report.js
@@ -21,11 +21,12 @@
             vm.reportTimeWindowMSDuration = 0;
             vm.creatingReport = false;
             vm.subarrayReportSensorsRegex = "subarray...state|subarray...maintenance|subarray...product|subarray...band|sched.mode..";
-            vm.receptorsReportSensorsRegex = "^(m0..|ant.).mode|pool.resources.free|subarray...pool.resources|resources.faulty|resources.in.maintenance";
+            vm.receptorsReportSensorsRegex = "^(m0..|ant.).windstow.active|pool.resources.free|subarray...pool.resources|resources.faulty|resources.in.maintenance";
             vm.poolResourcesAssignedDurations = {};
             vm.poolResourcesFreeDurations = {};
             vm.poolResourcesFaultyDurations = {};
             vm.poolResourcesMaintenanceDurations = {};
+            vm.windstowReceptorReportResults = [];
 
             //TODO probably get from config
             vm.poolResourcesAssignedToSubarraysDurations = {
@@ -53,6 +54,7 @@
                 vm.poolResourcesFreeDurations = {};
                 vm.poolResourcesFaultyDurations = {};
                 vm.poolResourcesMaintenanceDurations = {};
+                vm.windstowReceptorReportResults = [];
                 vm.poolResourcesAssignedToSubarraysDurations = {
                     subarray_1: {},
                     subarray_2: {},
@@ -238,6 +240,8 @@
                                     }
                                     vm.poolResourcesMaintenanceDurations[resources[i]].durationSeconds += item[2];
                                 }
+                            } else if (reportItem.sensorName.search('windstow.active') > -1) {
+                                vm.windstowReceptorReportResults.push(reportItem);
                             }
                             vm.receptorReportResults.push(reportItem);
                         });

--- a/app/reports/utilisation-report.js
+++ b/app/reports/utilisation-report.js
@@ -320,15 +320,18 @@
                                 }
                                 resources.forEach(function (resource) {
                                     if (!vm.poolResourcesAssignedDurations[resource]) {
-                                        vm.poolResourcesAssignedDurations[resource] = {durationTotalSeconds: 0};
+                                        vm.poolResourcesAssignedDurations[resource] = {durationTotalSeconds: 0, percentageTotal: '0%', durationTotal: '0:00:00'};
                                         vm.resourceItemColumns.forEach(function (col) {
                                             vm.poolResourcesAssignedDurations[resource][col] = {};
                                         });
                                     }
-                                    vm.poolResourcesAssignedDurations[resource].durationTotalSeconds += reportItem.durationSeconds;
-                                    duration = moment.duration(vm.poolResourcesAssignedDurations[resource].durationTotalSeconds, 's');
-                                    vm.poolResourcesAssignedDurations[resource].durationTotal = vm.durationToString(duration);
-                                    vm.poolResourcesAssignedDurations[resource].percentageTotal = vm.percentageOfTotalToString(vm.poolResourcesAssignedDurations[resource].durationTotalSeconds);
+                                    if (vm.subarrayNrs.indexOf(key) > -1) {
+                                        vm.poolResourcesAssignedDurations[resource].durationTotalSeconds += reportItem.durationSeconds;
+                                        duration = moment.duration(vm.poolResourcesAssignedDurations[resource].durationTotalSeconds, 's');
+                                        vm.poolResourcesAssignedDurations[resource].durationTotal = vm.durationToString(duration);
+                                        vm.poolResourcesAssignedDurations[resource].percentageTotal = vm.percentageOfTotalToString(vm.poolResourcesAssignedDurations[resource].durationTotalSeconds);
+                                    }
+
                                     if (!vm.poolResourcesAssignedDurations[resource][key].value) {
                                         vm.poolResourcesAssignedDurations[resource][key] = reportItem;
                                     } else {
@@ -380,7 +383,7 @@
                             }
                         });
                         var SBIdCodesList = Object.keys(SBIdCodes);
-                        if (SBIdCodesList.lengh > 0) {
+                        if (SBIdCodesList.length > 0) {
                             vm.fetchSBDetails(SBIdCodesList);
                         }
                     }

--- a/app/reports/utilisation-report.js
+++ b/app/reports/utilisation-report.js
@@ -273,9 +273,9 @@
                         endTime: vm.endDatetimeReadable,
                         filter: vm.searchInputText},
                         { notify: false, reload: false });
-                var startDate = moment(vm.startDatetimeReadable).toDate().getTime();
-                var endDate =  moment(vm.endDatetimeReadable).toDate().getTime();
-                vm.reportTimeWindowSecondsDuration = Math.abs(endDate - startDate) / 1000;
+                var startDate = moment.utc(vm.startDatetimeReadable).toDate().getTime() / 1000;
+                var endDate =  moment.utc(vm.endDatetimeReadable).toDate().getTime() / 1000;
+                vm.reportTimeWindowSecondsDuration = Math.abs(endDate - startDate);
                 vm.reportTimeWindowSecondsDurationReadable = vm.durationToString(moment.duration(vm.reportTimeWindowSecondsDuration, 's'));
                 vm.createSubarraysReport(startDate, endDate);
                 vm.createReceptorsReport(startDate, endDate);

--- a/app/reports/utilisation-report.js
+++ b/app/reports/utilisation-report.js
@@ -3,8 +3,8 @@
     angular.module('katGui')
         .controller('UtilisationReportCtrl', UtilisationReportCtrl);
 
-        function UtilisationReportCtrl($rootScope, $scope, $localStorage, $filter, DataService,
-                                    $log, $stateParams, NotifyService, $timeout, $state) {
+        function UtilisationReportCtrl($rootScope, $scope, $localStorage, $filter, DataService, ObsSchedService,
+                                       $q, $log, $stateParams, NotifyService, $timeout, $state, ConfigService) {
 
             var vm = this;
             var DATETIME_FORMAT = 'YYYY-MM-DD HH:mm:ss';
@@ -13,56 +13,45 @@
             vm.startTime.setMinutes(0);
             vm.startTime.setSeconds(0);
             vm.endTime = new Date();
-            vm.endTime.setHours(23);
-            vm.endTime.setMinutes(59);
-            vm.endTime.setSeconds(59);
             vm.startDatetimeReadable = moment(vm.startTime.getTime()).format(DATETIME_FORMAT);
             vm.endDatetimeReadable = moment(vm.endTime.getTime()).format(DATETIME_FORMAT);
             vm.reportTimeWindowMSDuration = 0;
             vm.creatingReceptorReport = false;
             vm.creatingSubarrayReport = false;
-            vm.subarrayReportSensorsRegex = "sched.active.schedule..|subarray...state|subarray...maintenance|subarray...product|subarray...band|sched.mode..";
-            vm.receptorsReportSensorsRegex = "^(m0..|ant.).windstow.active|pool.resources.free|subarray...pool.resources|resources.faulty|resources.in.maintenance|sys.interlock.state";
+            vm.subarrayReportSensorsRegex = "subarray...state|subarray...maintenance|subarray...product|subarray...band|sched.mode..";
+            vm.receptorsReportSensorsRegex = "^(m0..|ant.).windstow.active|^(m0..|ant.).mode|pool.resources.free|subarray...pool.resources|resources.faulty|resources.in.maintenance|sys.interlock.state";
+            vm.scheduleReportSensorsRegex = "sched.active.schedule..";
             vm.poolResourcesAssignedDurations = {};
             vm.poolResourcesFreeDurations = {};
             vm.poolResourcesFaultyDurations = {};
             vm.poolResourcesMaintenanceDurations = {};
             vm.interlockReceptorReportResults = [];
-
-            //TODO probably get from config
-            vm.poolResourcesAssignedToSubarraysDurations = {
-                subarray_1: {},
-                subarray_2: {},
-                subarray_3: {},
-                subarray_4: {}
-            };
-
-            vm.reportFields = [
-                {label: 'Sensor', value: 'sensorName'},
-                {label: 'Value', value: 'value'},
-                {label: 'Duration', value: 'duration'},
-                {label: '% of total', value: 'percentageOfTotal'}
-            ];
+            vm.receptorModeDurations = [];
+            vm.SBDetails = [];
+            vm.subarrayNrs = [];
 
             if ($stateParams.filter) {
                 vm.searchInputText = $stateParams.filter;
             }
 
             vm.clearReportsData = function () {
+                vm.SBDetails = [];
                 vm.subarrayReportResults = [];
                 vm.receptorReportResults = [];
+                vm.scheduleReportResults = [];
                 vm.poolResourcesAssignedDurations = {};
                 vm.poolResourcesFreeDurations = {};
                 vm.poolResourcesFaultyDurations = {};
                 vm.poolResourcesMaintenanceDurations = {};
                 vm.interlockReceptorReportResults = [];
-                vm.poolResourcesAssignedToSubarraysDurations = {
-                    subarray_1: {},
-                    subarray_2: {},
-                    subarray_3: {},
-                    subarray_4: {}
-                };
+                vm.receptorModeDurations = [];
+                vm.poolResourcesAssignedToSubarraysDurations = {};
+                for (var i = 0; i < vm.subarrayNrs.length; i++) {
+                    vm.poolResourcesAssignedToSubarraysDurations['subarray_' + vm.subarrayNrs[i]] = {};
+                }
             };
+
+            vm.clearReportsData();
 
             vm.onStartTimeSet = function () {
                 vm.startDatetimeReadable = moment(vm.startTime.getTime()).format(DATETIME_FORMAT);
@@ -73,80 +62,202 @@
             };
 
             vm.exportPdf = function(){
-                alert("UNIMPLEMENTED");
-                // vm.exportingPdf = true;
-                // var pdf = new jsPDF('l', 'pt');
-                // var exportTime = moment.utc().format(DATETIME_FORMAT);
-                // var query = "?start_time=" + vm.startDatetimeReadable + "&end_time=" + vm.endDatetimeReadable;
-                //
-                // vm.filteredReportUserlogs.forEach(function (userlog) {
-                //     userlog.userName = userlog.user.name;
-                //     var tagNames = [];
-                //     userlog.tags.forEach(function (tag) {
-                //         tagNames.push(tag.name);
-                //     });
-                //     userlog.tag_list = tagNames.join(',');
-                // });
-                //
-                // var columns = [
-                //     {title: "User", dataKey: "userName"},
-                //     {title: "Start", dataKey: "start_time"},
-                //     {title: "End", dataKey: "end_time"},
-                //     {title: "Content", dataKey: "content"},
-                //     {title: "Tags", dataKey: "tag_list"}
-                // ];
-                //
-                // pdf.setFontSize(20);
-                // pdf.text('Userlog Report - ' + exportTime + ' (UTC)', 20, 25);
-                // pdf.setFontSize(12);
-                // pdf.setFontSize(12);
-                // pdf.text(('From: ' + vm.startDatetimeReadable + '     To: ' + vm.endDatetimeReadable), 20, 45);
-                //
-                // pdf.autoTable(columns, vm.filteredReportUserlogs, {
-                //     startY: 55,
-                //     theme: 'striped',
-                //     margin: {top: 8, bottom: 8},
-                //     columnStyles: {
-                //         userName: {columnWidth: 80, overflow: 'linebreak'},
-                //         start_time: {columnWidth: 120},
-                //         end_time: {columnWidth: 120},
-                //         content: {overflow: 'linebreak'},
-                //         tag_list: {overflow: 'linebreak'}}});
-                //
-                // if (vm.includeActivityLogs) {
-                //     columns = [{title: "System Activity Logs", key: "msg"}];
-                //
-                //     UserLogService.queryActivityLogs(query).then(
-                //         function (result) {
-                //             pdf.autoTable(columns, result.data, {
-                //                 startY: pdf.autoTableEndPosY() + 50,
-                //                 theme: 'striped',
-                //                 margin: {top: 8, bottom: 8}});
-                //             pdf.save('Userlog_Report_' + exportTime.replace(/ /g, '.') + '.pdf');
-                //             vm.exportingPdf = false;
-                //         }, function (error) {
-                //             $log.error(error);
-                //             vm.exportingPdf = false;
-                //         });
-                // } else {
-                //     pdf.save('Userlog_Report_' + exportTime.replace(/ /g, '.') + '.pdf');
-                //     vm.exportingPdf = false;
-                // }
+                vm.exportingPdf = true;
+                var pdf = new jsPDF('l', 'pt');
+                var exportTime = moment.utc().format(DATETIME_FORMAT);
+
+                var sensorColumns = [
+                    {title: "Sensor", dataKey: "sensorName"},
+                    {title: "Value", dataKey: "value"},
+                    {title: "Duration", dataKey: "duration"},
+                    {title: "% of Total", dataKey: "percentageOfTotal"}
+                ];
+
+                pdf.setFontSize(20);
+                pdf.text('Utilisation Report - ' + exportTime + ' (UTC)', 20, 25);
+                pdf.setFontSize(12);
+                pdf.setFontSize(12);
+                pdf.text(('From: ' + vm.startDatetimeReadable + '     To: ' + vm.endDatetimeReadable), 20, 45);
+
+                pdf.setFontSize(20);
+                pdf.setFontStyle('italic');
+                pdf.text('Subarray Sensors', 20, 75);
+
+                pdf.autoTable(sensorColumns, vm.subarrayReportResults, {
+                    startY: 85,
+                    theme: 'striped',
+                    margin: {top: 8, bottom: 8},
+                    columnStyles: {
+                        sensorName: {columnWidth: 200, overflow: 'linebreak'},
+                        value: {},
+                        duration: {columnWidth: 80},
+                        percentageOfTotal: {columnWidth: 80}}});
+
+                pdf.setFontSize(20);
+                pdf.text('Resource Utilisation', 20, pdf.autoTableEndPosY() + 45);
+
+                var assignedToSubColumns = [
+                    {title: "Assigned to Subarray ", dataKey: "resourceName"},
+                    {title: "Duration", dataKey: "duration"},
+                    {title: "% of Total", dataKey: "percentageOfTotal"}
+                ];
+
+                vm.subarrayNrs.forEach(function (subNr) {
+                    assignedToSubColumns[0].title = "Assigned to Subarray " + subNr;
+
+                    var assignedToSubarray = [];
+                    var resourcesAssignedToSub = Object.keys(vm.poolResourcesAssignedToSubarraysDurations['subarray_' + subNr]);
+
+                    resourcesAssignedToSub.forEach(function (key) {
+                        var resource = vm.poolResourcesAssignedToSubarraysDurations['subarray_' + subNr][key];
+                        assignedToSubarray.push(resource);
+                    });
+
+                    if (assignedToSubarray.length > 0) {
+                        pdf.autoTable(assignedToSubColumns, assignedToSubarray, {
+                            startY: subNr === "1"? pdf.autoTableEndPosY() + 60 : pdf.autoTableEndPosY() + 8,
+                            theme: 'striped',
+                            margin: {top: 8, bottom: 8},
+                            columnStyles: {
+                                sensorName: {columnWidth: 200, overflow: 'linebreak'},
+                                value: {},
+                                duration: {columnWidth: 80},
+                                percentageOfTotal: {columnWidth: 80}}});
+                    }
+                });
+
+                assignedToSubColumns[0].title = "Free";
+                var assignedToFree = [];
+                var resourcesAssignedToFree = Object.keys(vm.poolResourcesFreeDurations);
+                resourcesAssignedToFree.forEach(function (key) {
+                    assignedToFree.push(vm.poolResourcesFreeDurations[key]);
+                });
+
+                if (assignedToFree.length > 0) {
+                    pdf.autoTable(assignedToSubColumns, assignedToFree, {
+                        startY: pdf.autoTableEndPosY() + 8,
+                        theme: 'striped',
+                        margin: {top: 8, bottom: 8},
+                        columnStyles: {
+                            sensorName: {columnWidth: 200, overflow: 'linebreak'},
+                            value: {},
+                            duration: {columnWidth: 80},
+                            percentageOfTotal: {columnWidth: 80}}});
+                }
+
+                assignedToSubColumns[0].title = "Faulty";
+                var assignedToFaulty = [];
+                var resourcesAssignedToFaulty = Object.keys(vm.poolResourcesFaultyDurations);
+                resourcesAssignedToFaulty.forEach(function (key) {
+                    assignedToFaulty.push(vm.poolResourcesFaultyDurations[key]);
+                });
+
+                if (assignedToFaulty.length > 0) {
+                    pdf.autoTable(assignedToSubColumns, assignedToFaulty, {
+                        startY: pdf.autoTableEndPosY() + 8,
+                        theme: 'striped',
+                        margin: {top: 8, bottom: 8},
+                        columnStyles: {
+                            sensorName: {columnWidth: 200, overflow: 'linebreak'},
+                            value: {},
+                            duration: {columnWidth: 80},
+                            percentageOfTotal: {columnWidth: 80}}});
+                }
+
+                assignedToSubColumns[0].title = "In Maintenance";
+                var assignedToInMaintenance = [];
+                var resourcesAssignedToInMaintenance = Object.keys(vm.poolResourcesMaintenanceDurations);
+                resourcesAssignedToInMaintenance.forEach(function (key) {
+                    assignedToInMaintenance.push(vm.poolResourcesMaintenanceDurations[key]);
+                });
+
+                if (assignedToInMaintenance.length > 0) {
+                    pdf.autoTable(assignedToSubColumns, assignedToInMaintenance, {
+                        startY: pdf.autoTableEndPosY() + 8,
+                        theme: 'striped',
+                        margin: {top: 8, bottom: 8},
+                        columnStyles: {
+                            sensorName: {columnWidth: 200, overflow: 'linebreak'},
+                            value: {},
+                            duration: {columnWidth: 80},
+                            percentageOfTotal: {columnWidth: 80}}});
+                }
+
+                pdf.text('Receptor Modes', 20, pdf.autoTableEndPosY() + 45);
+                pdf.autoTable(sensorColumns, vm.receptorModeDurations, {
+                    startY: pdf.autoTableEndPosY() + 60,
+                    theme: 'striped',
+                    margin: {top: 8, bottom: 8},
+                    columnStyles: {
+                        sensorName: {columnWidth: 200, overflow: 'linebreak'},
+                        value: {},
+                        duration: {columnWidth: 80},
+                        percentageOfTotal: {columnWidth: 80}}});
+
+                pdf.text('Interlock / Windstow', 20, pdf.autoTableEndPosY() + 45);
+                pdf.autoTable(sensorColumns, vm.interlockReceptorReportResults, {
+                    startY: pdf.autoTableEndPosY() + 60,
+                    theme: 'striped',
+                    margin: {top: 8, bottom: 8},
+                    columnStyles: {
+                        sensorName: {columnWidth: 200, overflow: 'linebreak'},
+                        value: {},
+                        duration: {columnWidth: 80},
+                        percentageOfTotal: {columnWidth: 80}}});
+
+                pdf.text('Active Schedule Blocks', 20, pdf.autoTableEndPosY() + 45);
+                pdf.autoTable(sensorColumns, vm.scheduleReportResults, {
+                    startY: pdf.autoTableEndPosY() + 60,
+                    theme: 'striped',
+                    margin: {top: 8, bottom: 8},
+                    columnStyles: {
+                        sensorName: {columnWidth: 200, overflow: 'linebreak'},
+                        value: {},
+                        duration: {columnWidth: 80},
+                        percentageOfTotal: {columnWidth: 80}}});
+
+                var sbColumns = [
+                    {title: "Id Code", dataKey: "id_code"},
+                    {title: "Owner", dataKey: "owner"},
+                    {title: "Description", dataKey: "description"},
+                    {title: "State", dataKey: "state"},
+                    {title: "Outcome", dataKey: "outcome"},
+                    {title: "Duration", dataKey: "duration"},
+                    {title: "% of Total", dataKey: "percentageOfTotal"},
+                ];
+
+                pdf.text('Active Schedule Block Details', 20, pdf.autoTableEndPosY() + 45);
+                pdf.autoTable(sbColumns, vm.SBDetails, {
+                    startY: pdf.autoTableEndPosY() + 60,
+                    theme: 'striped',
+                    margin: {top: 8, bottom: 8},
+                    columnStyles: {
+                        id_code: {columnWidth: 85},
+                        owner: {columnWidth: 85},
+                        description: {overflow: 'linebreak'},
+                        state: {columnWidth: 85},
+                        outcome: {columnWidth: 85},
+                        duration: {columnWidth: 80},
+                        percentageOfTotal: {columnWidth: 80}}});
+
+                pdf.save('utilisation_report_' + exportTime.replace(/ /g, '.') + '.pdf');
+                vm.exportingPdf = false;
             };
 
             vm.createReport = function () {
-                vm.createSubarraysReport();
-                vm.createReceptorsReport();
+                vm.clearReportsData();
+                vm.createSubarraysReport().then(vm.createReceptorsReport).then(vm.createScheduleReport);
             };
 
             vm.createSubarraysReport = function () {
+                var deferred = $q.defer();
                 vm.creatingSubarrayReport = true;
                 $state.go('utilisation-report', {
                         startTime: vm.startDatetimeReadable,
                         endTime: vm.endDatetimeReadable,
                         filter: vm.searchInputText},
                         { notify: false, reload: false });
-                vm.clearReportsData();
+
                 var startDate = moment(vm.startDatetimeReadable).toDate().getTime();
                 var endDate =  moment(vm.endDatetimeReadable).toDate().getTime();
                 DataService.sampleValueDuration(vm.subarrayReportSensorsRegex, startDate, endDate).then(function (result) {
@@ -169,21 +280,25 @@
                         });
                     }
                     vm.creatingSubarrayReport = false;
+                    deferred.resolve();
                 }, function (result) {
                     vm.creatingSubarrayReport = false;
                     NotifyService.showSimpleDialog('Error creating report', result.data);
                     $log.error(result);
+                    deferred.reject();
                 });
+                return deferred.promise;
             };
 
             vm.createReceptorsReport = function () {
+                var deferred = $q.defer();
                 vm.creatingReceptorReport = true;
                 $state.go('utilisation-report', {
                         startTime: vm.startDatetimeReadable,
                         endTime: vm.endDatetimeReadable,
                         filter: vm.searchInputText},
                         { notify: false, reload: false });
-                vm.clearReportsData();
+
                 var startDate = moment(vm.startDatetimeReadable).toDate().getTime();
                 var endDate =  moment(vm.endDatetimeReadable).toDate().getTime();
                 DataService.sampleValueDuration(vm.receptorsReportSensorsRegex, startDate, endDate).then(function (result) {
@@ -212,7 +327,7 @@
                                         vm.poolResourcesAssignedDurations[resources[i]] = { value: 'assigned to a subarray', durationSeconds: 0, duration: '0:00:00'};
                                     }
                                     if (!vm.poolResourcesAssignedDurations[resources[i]][subarray]) {
-                                        vm.poolResourcesAssignedDurations[resources[i]][subarray] = { sensorName: resources[i], value: subarray, durationSeconds: 0, duration: '0:00:00'};
+                                        vm.poolResourcesAssignedDurations[resources[i]][subarray] = {sensorName: resources[i], value: subarray, durationSeconds: 0, duration: '0:00:00'};
                                     }
                                     vm.poolResourcesAssignedDurations[resources[i]].durationSeconds += item[2];
                                     vm.poolResourcesAssignedDurations[resources[i]][subarray].durationSeconds += item[2];
@@ -223,7 +338,7 @@
                                 value = 'free';
                                 for (i = 0; i < resources.length; i++) {
                                     if (!vm.poolResourcesFreeDurations[resources[i]]) {
-                                        vm.poolResourcesFreeDurations[resources[i]] = { value: value, durationSeconds: 0, duration: '0:00:00'};
+                                        vm.poolResourcesFreeDurations[resources[i]] = {resourceName: resources[i], value: value, durationSeconds: 0, duration: '0:00:00'};
                                     }
                                     vm.poolResourcesFreeDurations[resources[i]].durationSeconds += item[2];
                                 }
@@ -233,7 +348,7 @@
                                 value = 'faulty';
                                 for (i = 0; i < resources.length; i++) {
                                     if (!vm.poolResourcesFaultyDurations[resources[i]]) {
-                                        vm.poolResourcesFaultyDurations[resources[i]] = { value: value, durationSeconds: 0, duration: '0:00:00'};
+                                        vm.poolResourcesFaultyDurations[resources[i]] = {resourceName: resources[i], value: value, durationSeconds: 0, duration: '0:00:00'};
                                     }
                                     vm.poolResourcesFaultyDurations[resources[i]].durationSeconds += item[2];
                                 }
@@ -243,7 +358,7 @@
                                 value = 'in_maintenance';
                                 for (i = 0; i < resources.length; i++) {
                                     if (!vm.poolResourcesMaintenanceDurations[resources[i]]) {
-                                        vm.poolResourcesMaintenanceDurations[resources[i]] = { value: value, durationSeconds: 0, duration: '0:00:00'};
+                                        vm.poolResourcesMaintenanceDurations[resources[i]] = {resourceName: resources[i], value: value, durationSeconds: 0, duration: '0:00:00'};
                                     }
                                     vm.poolResourcesMaintenanceDurations[resources[i]].durationSeconds += item[2];
                                 }
@@ -251,6 +366,8 @@
                                 vm.interlockReceptorReportResults.push(reportItem);
                             } else if (reportItem.sensorName.search('sys.interlock.state') > -1) {
                                 vm.interlockReceptorReportResults.push(reportItem);
+                            } else if (reportItem.sensorName.search('^(m0..|ant.).mode') > -1) {
+                                vm.receptorModeDurations.push(reportItem);
                             }
                             vm.receptorReportResults.push(reportItem);
                         });
@@ -290,26 +407,97 @@
                             vm.poolResourcesMaintenanceDurations[key].percentageOfTotal = parseFloat(100 * item.durationSeconds / vm.reportTimeWindowSecondsDuration).toFixed(2) + '%';
                         });
                     }
+                    deferred.resolve();
                 }, function (result) {
                     vm.creatingReceptorReport = false;
                     NotifyService.showSimpleDialog('Error creating report', result.data);
                     $log.error(result);
+                    deferred.reject();
+                });
+                return deferred.promise;
+            };
+
+            vm.createScheduleReport = function () {
+                var deferred = $q.defer();
+                vm.creatingScheduleReport = true;
+                $state.go('utilisation-report', {
+                        startTime: vm.startDatetimeReadable,
+                        endTime: vm.endDatetimeReadable,
+                        filter: vm.searchInputText},
+                        { notify: false, reload: false });
+
+                var startDate = moment(vm.startDatetimeReadable).toDate().getTime();
+                var endDate =  moment(vm.endDatetimeReadable).toDate().getTime();
+                DataService.sampleValueDuration(vm.scheduleReportSensorsRegex, startDate, endDate).then(function (result) {
+                    vm.reportTimeWindowSecondsDuration = Math.abs(endDate - startDate) / 1000;
+                    var SBIdCodes = {};
+                    if (result.data) {
+                        result.data.forEach(function (item) {
+                            var duration = moment.duration(item[2], 's');
+                            var reportItem = {
+                                sensorName: item[0],
+                                value: item[1],
+                                durationSeconds: item[2],
+                                duration: Math.floor(duration.asHours()) + moment.utc(duration.asMilliseconds()).format(":mm:ss")
+                            };
+
+                            if (reportItem.duration) {
+                                //convert to milliseconds and then to percentageOfTotal
+                                reportItem.percentageOfTotal = parseFloat(100 * reportItem.durationSeconds / vm.reportTimeWindowSecondsDuration).toFixed(2) + '%';
+                            }
+                            vm.scheduleReportResults.push(reportItem);
+                            if (reportItem.value.length > 0) {
+                                reportItem.value.split(',').forEach(function (idCode) {
+                                    SBIdCodes[idCode] = true;
+                                });
+                            }
+                        });
+                        vm.fetchSBDetails(Object.keys(SBIdCodes));
+                    }
+                    vm.creatingScheduleReport = false;
+                    deferred.resolve();
+                }, function (result) {
+                    vm.creatingScheduleReport = false;
+                    NotifyService.showSimpleDialog('Error creating report', result.data);
+                    $log.error(result);
+                    deferred.reject();
+                });
+                return deferred.promise;
+            };
+
+            vm.fetchSBDetails = function (sbIdCodes) {
+                ObsSchedService.getScheduleBlockDetails(sbIdCodes).then(function (result) {
+                    vm.SBDetails = JSON.parse(result.data.result);
+                    vm.SBDetails.forEach(function (sb) {
+                        if (sb.actual_end_time && sb.actual_start_time) {
+                            var startSeconds = moment.utc(sb.actual_start_time, DATETIME_FORMAT).toDate().getTime() / 1000;
+                            var endSeconds = moment.utc(sb.actual_end_time, DATETIME_FORMAT).toDate().getTime() / 1000;
+                            sb.durationSeconds = Math.abs(endSeconds - startSeconds);
+                            var duration = moment.duration(sb.durationSeconds, 's');
+                            sb.duration = Math.floor(duration.asHours()) + moment.utc(duration.asMilliseconds()).format(":mm:ss");
+                            sb.percentageOfTotal = parseFloat(100 * sb.durationSeconds / vm.reportTimeWindowSecondsDuration).toFixed(2) + '%';
+                        }
+                    });
                 });
             };
 
             vm.afterInit = function() {
-                var startTimeParam = moment($stateParams.startTime, DATETIME_FORMAT, true);
-                var endTimeParam = moment($stateParams.startTime, DATETIME_FORMAT, true);
-                if (startTimeParam.isValid() && endTimeParam.isValid()) {
-                    vm.startTime = startTimeParam.toDate();
-                    vm.endTime = endTimeParam.toDate();
-                    vm.startDatetimeReadable = $stateParams.startTime;
-                    vm.endDatetimeReadable = $stateParams.endTime;
-                    // vm.createReport();
-                } else if ($stateParams.startTime && $stateParams.endTime) {
-                    NotifyService.showSimpleDialog('Invalid Datetime URL Parameters',
-                        'Invalid datetime strings: ' + $stateParams.startTime + ' or ' + $stateParams.endTime + '. Format should be ' + DATETIME_FORMAT);
-                }
+                ConfigService.getSystemConfig().then(function (systemConfig) {
+                    vm.subarrayNrs = systemConfig.system.subarray_nrs.split(',');
+
+                    var startTimeParam = moment($stateParams.startTime, DATETIME_FORMAT, true);
+                    var endTimeParam = moment($stateParams.startTime, DATETIME_FORMAT, true);
+                    if (startTimeParam.isValid() && endTimeParam.isValid()) {
+                        vm.startTime = startTimeParam.toDate();
+                        vm.endTime = endTimeParam.toDate();
+                        vm.startDatetimeReadable = $stateParams.startTime;
+                        vm.endDatetimeReadable = $stateParams.endTime;
+                        vm.createReport();
+                    } else if ($stateParams.startTime && $stateParams.endTime) {
+                        NotifyService.showSimpleDialog('Invalid Datetime URL Parameters',
+                            'Invalid datetime strings: ' + $stateParams.startTime + ' or ' + $stateParams.endTime + '. Format should be ' + DATETIME_FORMAT);
+                    }
+                });
             };
 
             if ($rootScope.currentUser) {

--- a/app/reports/utilisation-report.js
+++ b/app/reports/utilisation-report.js
@@ -273,8 +273,8 @@
                         endTime: vm.endDatetimeReadable,
                         filter: vm.searchInputText},
                         { notify: false, reload: false });
-                var startDate = moment.utc(vm.startDatetimeReadable).toDate().getTime() / 1000;
-                var endDate =  moment.utc(vm.endDatetimeReadable).toDate().getTime() / 1000;
+                var startDate = moment(vm.startDatetimeReadable).unix();
+                var endDate =  moment(vm.endDatetimeReadable).unix();
                 vm.reportTimeWindowSecondsDuration = Math.abs(endDate - startDate);
                 vm.reportTimeWindowSecondsDurationReadable = vm.durationToString(moment.duration(vm.reportTimeWindowSecondsDuration, 's'));
                 vm.createSubarraysReport(startDate, endDate);
@@ -510,8 +510,8 @@
                     vm.SBDetails = JSON.parse(result.data.result);
                     vm.SBDetails.forEach(function (sb) {
                         if (sb.actual_end_time && sb.actual_start_time) {
-                            var startSeconds = moment.utc(sb.actual_start_time, DATETIME_FORMAT).toDate().getTime() / 1000;
-                            var endSeconds = moment.utc(sb.actual_end_time, DATETIME_FORMAT).toDate().getTime() / 1000;
+                            var startSeconds = moment(sb.actual_start_time, DATETIME_FORMAT).unix();
+                            var endSeconds = moment(sb.actual_end_time, DATETIME_FORMAT).unix();
                             sb.durationSeconds = Math.abs(endSeconds - startSeconds);
                             var duration = moment.duration(sb.durationSeconds, 's');
                             sb.duration = vm.durationToString(duration);
@@ -522,7 +522,7 @@
             };
 
             vm.durationToString = function (duration) {
-                return Math.floor(duration.asHours()) + moment.utc(duration.asMilliseconds()).format(":mm:ss");
+                return Math.floor(duration.asHours()) + moment(duration.asMilliseconds()).format(":mm:ss");
             };
 
             vm.percentageOfTotalToString = function (durationSeconds, totalSeconds) {

--- a/app/reports/utilisation-report.js
+++ b/app/reports/utilisation-report.js
@@ -47,6 +47,7 @@
                 vm.poolResourcesAssignedDurations = {};
                 vm.interlockReceptorReportResults = {};
                 vm.resourceItemColumns = [];
+                vm.reportTimeWindowSecondsDurationReadable = '';
 
                 vm.subarrayNrs.forEach(function (subNr) {
                     vm.subarrayMaintenanceDurations[subNr] = {};
@@ -210,6 +211,7 @@
                 var startDate = moment(vm.startDatetimeReadable).toDate().getTime();
                 var endDate =  moment(vm.endDatetimeReadable).toDate().getTime();
                 vm.reportTimeWindowSecondsDuration = Math.abs(endDate - startDate) / 1000;
+                vm.reportTimeWindowSecondsDurationReadable = vm.durationToString(moment.duration(vm.reportTimeWindowSecondsDuration, 's'));
                 vm.createSubarraysReport(startDate, endDate);
                 vm.createReceptorsReport(startDate, endDate);
                 vm.createInterlockReport(startDate, endDate);

--- a/app/reports/utilisation-report.less
+++ b/app/reports/utilisation-report.less
@@ -5,12 +5,25 @@
     }
 }
 
+.report-sb-item {
+    padding: 2px 8px;
+    &:hover {
+        background-color: rgba(215, 215, 215, 0.4);
+    }
+}
+
 .report-cell-item {
     min-width: 120px;
     max-width: 120px;
     padding: 2px 8px;
     text-align: center;
     cursor: auto;
+}
+
+.report-cell-item-long {
+    .report-cell-item;
+    min-width: 250px;
+    max-width: 250px;
 }
 
 .report-row-value-item {
@@ -27,6 +40,12 @@
     text-align: center;
     padding: 2px 8px;
     border-bottom: 1px solid rgba(158, 158, 158, 0.5);
+}
+
+.report-column-value-item-long {
+    .report-column-value-item;
+    min-width: 250px;
+    max-width: 250px;
 }
 
 .report-row-column-item {

--- a/app/reports/utilisation-report.less
+++ b/app/reports/utilisation-report.less
@@ -1,6 +1,5 @@
 .report-item {
     padding: 2px 8px;
-    min-height: 24px;
     &:hover {
         background-color: rgba(215, 215, 215, 0.3);
     }
@@ -10,5 +9,9 @@
     padding: 8px 8px 0 8px;
     font-size: 18px;
     font-weight: bold;
-    border-bottom: 1px solid rgba(158, 158, 158, 0.7);
+    background: rgba(127, 127, 127, 0.3);
+}
+
+.light-grey-background-03 {
+    background: rgba(127, 127, 127, 0.3);
 }

--- a/app/reports/utilisation-report.less
+++ b/app/reports/utilisation-report.less
@@ -7,9 +7,8 @@
 }
 
 .report-section-title-div {
-    min-height: 42px;
-    max-height: 42px;
-    padding: 8px;
+    padding: 8px 8px 0 8px;
     font-size: 18px;
     font-weight: bold;
+    border-bottom: 1px solid rgba(158, 158, 158, 0.7);
 }

--- a/app/reports/utilisation-report.less
+++ b/app/reports/utilisation-report.less
@@ -1,0 +1,15 @@
+.report-item {
+    padding: 2px 8px;
+    min-height: 24px;
+    &:hover {
+        background-color: rgba(215, 215, 215, 0.3);
+    }
+}
+
+.report-section-title-div {
+    min-height: 42px;
+    max-height: 42px;
+    padding: 8px;
+    font-size: 18px;
+    font-weight: bold;
+}

--- a/app/reports/utilisation-report.less
+++ b/app/reports/utilisation-report.less
@@ -12,6 +12,13 @@
     background: rgba(127, 127, 127, 0.3);
 }
 
+.report-section-sub-title-div {
+    padding: 8px 8px 0 8px;
+    font-size: 16px;
+    font-weight: bold;
+    background: rgba(210, 210, 210, 0.3);
+}
+
 .light-grey-background-03 {
     background: rgba(215, 215, 215, 0.2);
 }

--- a/app/reports/utilisation-report.less
+++ b/app/reports/utilisation-report.less
@@ -1,7 +1,7 @@
 .report-item {
     padding: 2px 8px;
     &:hover {
-        background-color: rgba(215, 215, 215, 0.3);
+        background-color: rgba(215, 215, 215, 0.4);
     }
 }
 
@@ -13,5 +13,5 @@
 }
 
 .light-grey-background-03 {
-    background: rgba(127, 127, 127, 0.3);
+    background: rgba(215, 215, 215, 0.2);
 }

--- a/app/reports/utilisation-report.less
+++ b/app/reports/utilisation-report.less
@@ -1,5 +1,5 @@
 .report-item {
-    padding: 2px 8px;
+    // padding: 2px 8px;
     &:hover {
         background-color: rgba(215, 215, 215, 0.4);
     }

--- a/app/reports/utilisation-report.less
+++ b/app/reports/utilisation-report.less
@@ -5,6 +5,39 @@
     }
 }
 
+.report-cell-item {
+    min-width: 120px;
+    max-width: 120px;
+    padding: 2px 8px;
+    text-align: center;
+    cursor: auto;
+}
+
+.report-row-value-item {
+    min-width: 120px;
+    max-width: 120px;
+    text-align: right;
+    padding: 2px 8px;
+    border-right: 1px solid rgba(158, 158, 158, 0.5);
+}
+
+.report-column-value-item {
+    min-width: 120px;
+    max-width: 120px;
+    text-align: center;
+    padding: 2px 8px;
+    border-bottom: 1px solid rgba(158, 158, 158, 0.5);
+}
+
+.report-row-column-item {
+    min-width: 120px;
+    max-width: 120px;
+    text-align: right;
+    padding: 2px 8px;
+    border-right: 1px solid rgba(158, 158, 158, 0.5);
+    border-bottom: 1px solid rgba(158, 158, 158, 0.5);
+}
+
 .report-section-title-div {
     padding: 8px 8px 0 8px;
     font-size: 18px;

--- a/app/scheduler/observations/observations-overview.html
+++ b/app/scheduler/observations/observations-overview.html
@@ -1,7 +1,7 @@
 <div flex layout="column" style="min-width: 1015px; min-height: 600px; margin: 0 8px 8px 8px" ng-controller="SubArrayExecutorOverview as vm">
     <div flex ng-repeat="subarray in vm.subarrays | orderBy:'id'" class="subarray-container md-whiteframe-z2"
         layout="row" flex style="min-height: 120px" md-theme="{{subarray.state === 'inactive'? 'grey' : subarray.state === 'active'? 'green' : subarray.state === 'error'? 'amber' : 'deep-purple'}}">
-        <div style="margin-left: 0; margin-top: 8px;" layout="column" flex>
+        <div layout="column" flex>
 
             <md-toolbar ng-class="{'md-hue-2': subarray.state !== 'inactive'}" class="md-whiteframe-z1" layout="row"
                 layout-align="center center" title="{{subarray.description}}" style="max-height: 48px; min-height: 48px; position: relative"

--- a/app/sensor-graph/sensor-graph.js
+++ b/app/sensor-graph/sensor-graph.js
@@ -484,7 +484,7 @@
                     vm.intervalNum = intervalTime.toString();
                     vm.intervalType = intervalParams[1];
                 } else {
-                    vm.intervalNum = 1;
+                    vm.intervalNum = '10';
                     vm.intervalType = 'm';
                 }
                 var sensorNames = $stateParams.sensors.split(',');

--- a/app/services/control-service.js
+++ b/app/services/control-service.js
@@ -1,7 +1,7 @@
 (function () {
 
     angular.module('katGui.services')
-        .constant('SERVER_URL', window.location.host === 'localhost:8000' ? 'http://portal.mkat.devkaroo.camlab.kat.ac.za' : window.location.origin)
+        .constant('SERVER_URL', window.location.host === 'localhost:8000' ? 'http://monctl.devf.camlab.kat.ac.za' : window.location.origin)
         .service('ControlService', ControlService);
 
     function ControlService($rootScope, $http, SERVER_URL, NotifyService, KatGuiUtil) {

--- a/app/services/data-service.js
+++ b/app/services/data-service.js
@@ -63,7 +63,7 @@
                 'sample-value-duration?sensors=' + sensorNames +
                 '&start=' + startDate +
                 '&end=' + endDate +
-                '&time_type=ms';
+                '&time_type=s';
                 return $http.get(requestStr);
         };
 

--- a/app/services/data-service.js
+++ b/app/services/data-service.js
@@ -58,6 +58,15 @@
             return $http(req);
         };
 
+        api.sampleValueDuration = function (sensorNames, startDate, endDate) {
+            var requestStr = urlBase +
+                'sample-value-duration?sensors=' + sensorNames +
+                '&start=' + startDate +
+                '&end=' + endDate +
+                '&time_type=ms';
+                return $http.get(requestStr);
+        };
+
         return api;
     }
 })();

--- a/app/services/obs-sched-service.js
+++ b/app/services/obs-sched-service.js
@@ -218,6 +218,14 @@
                 });
         };
 
+        api.getScheduleBlockDetails = function (idCodes) {
+            return $http(createRequest('post',
+                urlBase + '/sb/details',
+                {
+                    id_codes: idCodes.join(',')
+                }));
+        };
+
         api.getScheduledScheduleBlocks = function () {
             var deferred = $q.defer();
             $http(createRequest('get', urlBase + '/sb/scheduled'))

--- a/app/services/obs-sched-service.js
+++ b/app/services/obs-sched-service.js
@@ -494,8 +494,8 @@
 
         api.showSubarrayAndDataLogs = function (sub_nr) {
             if (ConfigService.GetKATTaskFileServerURL()) {
-                window.open(ConfigService.GetKATTaskFileServerURL() + "/logfile/kat.katsubarray" + sub_nr + ".log/tail/");
-                window.open(ConfigService.GetKATTaskFileServerURL() + "/logfile/kat.data_" + sub_nr + ".log/tail/");
+                window.open(ConfigService.GetKATLogFileServerURL() + "/logfile/kat.katsubarray" + sub_nr + ".log/tail/");
+                window.open(ConfigService.GetKATLogFileServerURL() + "/logfile/kat.data_" + sub_nr + ".log/tail/");
             } else {
                 NotifyService.showSimpleDialog('Error Viewing Logfile', 'There is no KATTaskFileServer IP defined in config, please contact CAM support.');
             }

--- a/app/widgets/navigation/navigation-widget-blocks.html
+++ b/app/widgets/navigation/navigation-widget-blocks.html
@@ -84,4 +84,11 @@
             <md-button flex class="md-raised md-primary" ng-click="$root.stateGo('about')" layout="row"><span class="fa fa-info"></span><span flex>About KATGUI</span></md-button>
         </div>
     </div>
+
+    <div layout="column" class="nav-widget-container">
+        <md-toolbar class="md-whiteframe-z1 md-toolbar-tools-medium"><span flex>Reports</span></md-toolbar>
+        <div flex class="md-whiteframe-z1 nav-widget-button-container" md-theme="{{$root.themePrimaryButtons}}" layout="column">
+            <md-button flex class="md-raised md-primary" ng-click="$root.stateGo('utilisation-report')" layout="row"><span class="fa fa-file-pdf-o"></span><span flex>Utilisation Report</span></md-button>
+        </div>
+    </div>
 </div>

--- a/index.html
+++ b/index.html
@@ -254,6 +254,19 @@
                     </md-item-content>
                 </md-item>
                 <md-item>
+                    <md-item-content class="menu-item-divider" layout="row" layout-align="start center">
+                    </md-item-content>
+                </md-item>
+                <md-item>
+                    <md-item-content class="menu-item" layout="row" layout-align="start center" ng-click="vm.sideNavStateGo('utilisation-report')">
+                        <md-button flex><span class="fa fa-file-pdf-o"></span><span>Utilisation Report</span></md-button>
+                    </md-item-content>
+                </md-item>
+                <md-item>
+                    <md-item-content class="menu-item-divider" layout="row" layout-align="start center">
+                    </md-item-content>
+                </md-item>
+                <md-item>
                     <md-item-content style="border-bottom: 1px solid #e5e5e5;" class="menu-item" layout="row" layout-align="start center" ng-click="vm.sideNavStateGo('weather')">
                         <md-button flex><span class="fa fa-cloud"></span><span>Weather</span></md-button>
                     </md-item-content>

--- a/index.html
+++ b/index.html
@@ -118,6 +118,7 @@
 <script src="app/device-status/device-status.js"></script>
 <script src="app/instrumental-config/instrumental-config.js"></script>
 <script src="app/activity/activity.js"></script>
+<script src="app/reports/utilisation-report.js"></script>
 <!-- Add New Component JS Above -->
 
 <!--dont use md-whiteframe class because it leaves black artifacts on sidenav-->


### PR DESCRIPTION
Merge with https://github.com/ska-sa/katportal/pull/231

This display shows the following (from devf data): 

![screen shot 2016-09-12 at 1 41 22 pm](https://cloud.githubusercontent.com/assets/8371143/18436727/069dc3ce-78fa-11e6-8bac-36df912371f8.png)
![screen shot 2016-09-12 at 1 41 31 pm](https://cloud.githubusercontent.com/assets/8371143/18436728/069fbabc-78fa-11e6-9fb1-390c3776a588.png)

Then the export pdf button will give you:
<img width="1184" alt="screen shot 2016-09-12 at 3 03 58 pm" src="https://cloud.githubusercontent.com/assets/8371143/18436760/3ac75c32-78fa-11e6-815d-6bf6d063821b.png">
<img width="1180" alt="screen shot 2016-09-12 at 3 04 05 pm" src="https://cloud.githubusercontent.com/assets/8371143/18436757/3ab671d8-78fa-11e6-9397-eebdf3997c60.png">
<img width="1159" alt="screen shot 2016-09-12 at 3 04 19 pm" src="https://cloud.githubusercontent.com/assets/8371143/18436759/3abda872-78fa-11e6-835c-1735a7f56429.png">
<img width="1155" alt="screen shot 2016-09-12 at 3 04 23 pm" src="https://cloud.githubusercontent.com/assets/8371143/18436758/3ab83338-78fa-11e6-8ce5-147d69e58f6d.png">

This is a quick and dirty and could probably benefit from some refactoring, but it is good enough for now because it works.