### PR TITLE
Development mode; sensor graph improvements; bug fixes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,20 +1,18 @@
 node('docker') {
     stage 'Cleanup workspace'
-    dir('katgui') {
-        deleteDir()
-    }
-    sh 'rm -rf *.deb'
+    sh 'chmod 777 -R .'
+    sh 'rm -rf *'
 
     docker.image('camguinode:latest').inside('-u root') {
         stage 'Checkout SCM'
-            checkout([
-                   $class: 'GitSCM',
-                   branches: [[name: "${env.BRANCH_NAME}"]],
-                   doGenerateSubmoduleConfigurations: false,
-                   extensions: [[$class: 'LocalBranch', localBranch: "${env.BRANCH_NAME}"], [$class: 'PruneStaleBranch']],
-                   submoduleCfg: [],
-                   userRemoteConfigs: [[credentialsId: 'd725cdb1-3e38-42ca-9193-979c69452685', url: 'https://github.com/ska-sa/katgui.git']]
-               ])
+           checkout([
+               $class: 'GitSCM',
+               branches: [[name: "refs/heads/${env.BRANCH_NAME}"]],
+               extensions: [[$class: 'LocalBranch']],
+               userRemoteConfigs: scm.userRemoteConfigs,
+               doGenerateSubmoduleConfigurations: false,
+               submoduleCfg: []
+           ])
 
         stage 'Install & Unit Tests'
             timeout(time: 30, unit: 'MINUTES') {
@@ -27,7 +25,7 @@ node('docker') {
             // chmod for cleanup stage
             sh 'chmod 777 -R katgui *.deb'
 
-        stage 'Archive build artifact: .whl & .deb'
+        stage 'Archive build artifact .deb'
             archive '*.deb'
 
         stage 'Trigger downstream publish'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,10 @@
 node('docker') {
-    stage 'Cleanup workspace'
-    sh 'chmod 777 -R .'
-    sh 'rm -rf *'
 
     docker.image('camguinode:latest').inside('-u root') {
+        stage 'Cleanup workspace'
+            sh 'chmod 777 -R .'
+            sh 'rm -rf *'
+
         stage 'Checkout SCM'
            checkout([
                $class: 'GitSCM',
@@ -22,8 +23,6 @@ node('docker') {
         stage 'Build .whl & .deb'
             sh 'mv dist/ katgui'
             sh 'fpm -s "dir" -t "deb" --name katgui --version $(kat-get-version.py) --description "The operator interface for SKA-SA" katgui=/var/www'
-            // chmod for cleanup stage
-            sh 'chmod 777 -R katgui *.deb'
 
         stage 'Archive build artifact .deb'
             archive '*.deb'

--- a/app/app.js
+++ b/app/app.js
@@ -80,7 +80,7 @@
         $rootScope.connectedToMonitor = true;
 
         $rootScope.devMode = window.location.host === 'localhost:8000';
-        $rootScope.portalUrl = $rootScope.devMode? $localStorage.devModePortalURL : window.location.host;
+        $rootScope.portalUrl = $rootScope.devMode? $localStorage.devModePortalURL : window.location.origin;
 
         $rootScope.possibleRoles = ['lead_operator', 'expert', 'control_authority', 'operator', 'read_only'];
         $rootScope.rolesMap = {

--- a/app/app.js
+++ b/app/app.js
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
 
-    angular.module('katGui', ['ngMaterial',
+    angular.module('katGui', ['ngMaterial', 'ngMessages',
         'ui.bootstrap', 'ui.utils', 'ui.router',
         'ngAnimate', 'katGui.services',
         'katGui.admin',
@@ -81,6 +81,9 @@
 
         $rootScope.devMode = window.location.host === 'localhost:8000';
         $rootScope.portalUrl = $rootScope.devMode? $localStorage.devModePortalURL : window.location.origin;
+        if ($rootScope.portalUrl === 'http://') {
+            $rootScope.portalUrl = '';
+        }
 
         $rootScope.possibleRoles = ['lead_operator', 'expert', 'control_authority', 'operator', 'read_only'];
         $rootScope.rolesMap = {
@@ -91,9 +94,9 @@
             read_only: 'Monitor Only'
         };
 
-        $rootScope.getSystemConfig = function () {
+        $rootScope.getSystemConfig = function (forceConfig) {
             ObsSchedService.subarrays.splice(0, ObsSchedService.subarrays.length);
-            ConfigService.getSystemConfig().then(function (systemConfig) {
+            ConfigService.getSystemConfig(forceConfig).then(function (systemConfig) {
                 $rootScope.systemConfig = systemConfig;
                 StatusService.controlledResources = systemConfig.katobs.controlled_resources.split(',');
                 if (systemConfig.vds && systemConfig.vds.vds_source) {
@@ -103,7 +106,7 @@
                 $rootScope.confConnectionError = null;
             }, function (error) {
                 if ($rootScope.portalUrl) {
-                    $rootScope.confConnectionError = 'Could not connect to ' + $rootScope.portalUrl + '/katconf.';
+                    $rootScope.confConnectionError = 'Could not connect to ' + $rootScope.portalUrl + '/katconf. Is the URL correct?';
                 } else {
                     $rootScope.confConnectionError = 'Development mode: Please specify a host to connect to. E.g. monctl.devf.camlab.kat.ac.za';
                 }
@@ -112,7 +115,7 @@
                     $timeout.cancel(vm.getSystemConfigTimeout);
                 }
                 vm.getSystemConfigTimeout = $timeout(function () {
-                    $rootScope.getSystemConfig();
+                    $rootScope.getSystemConfig(forceConfig);
                 }, 10000);
             });
         };

--- a/app/app.js
+++ b/app/app.js
@@ -56,7 +56,7 @@
         .controller('ApplicationCtrl', ApplicationCtrl);
 
     function ApplicationCtrl($rootScope, $scope, $state, $interval, $mdSidenav, $localStorage, THEMES, AlarmsService,
-                             ConfigService, USER_ROLES, MonitorService, KatGuiUtil, SessionService, SERVER_URL,
+                             ConfigService, USER_ROLES, MonitorService, KatGuiUtil, SessionService,
                              CENTRAL_LOGGER_PORT, $log, NotifyService, $timeout, StatusService, ObsSchedService) {
         var vm = this;
         SessionService.recoverLogin();
@@ -79,6 +79,9 @@
         $rootScope.showVideoLinks = false;
         $rootScope.connectedToMonitor = true;
 
+        $rootScope.devMode = window.location.host === 'localhost:8000';
+        $rootScope.portalUrl = $rootScope.devMode? $localStorage.devModePortalURL : window.location.host;
+
         $rootScope.possibleRoles = ['lead_operator', 'expert', 'control_authority', 'operator', 'read_only'];
         $rootScope.rolesMap = {
             lead_operator: 'Lead Operator',
@@ -99,7 +102,11 @@
                 $rootScope.systemType = systemConfig.system.system_conf.replace('katcamconfig/systems/', '').replace('.conf', '');
                 $rootScope.confConnectionError = null;
             }, function (error) {
-                $rootScope.confConnectionError = 'Could not connect to ' + SERVER_URL + '/katconf.';
+                if ($rootScope.portalUrl) {
+                    $rootScope.confConnectionError = 'Could not connect to ' + $rootScope.portalUrl + '/katconf.';
+                } else {
+                    $rootScope.confConnectionError = 'Development mode: Please specify a host to connect to. E.g. monctl.devf.camlab.kat.ac.za';
+                }
                 //retry every 10 seconds to get the system config
                 if (vm.getSystemConfigTimeout) {
                     $timeout.cancel(vm.getSystemConfigTimeout);

--- a/app/app.js
+++ b/app/app.js
@@ -59,7 +59,6 @@
                              ConfigService, USER_ROLES, MonitorService, KatGuiUtil, SessionService,
                              CENTRAL_LOGGER_PORT, $log, NotifyService, $timeout, StatusService, ObsSchedService) {
         var vm = this;
-        SessionService.recoverLogin();
 
         var theme = _.find(THEMES, function (theme) {
             return $localStorage['selectedTheme'] === theme.name;
@@ -93,6 +92,8 @@
             operator: 'Operator',
             read_only: 'Monitor Only'
         };
+
+        SessionService.recoverLogin();
 
         $rootScope.getSystemConfig = function (forceConfig) {
             ObsSchedService.subarrays.splice(0, ObsSchedService.subarrays.length);

--- a/app/d3/multi-line-chart.js
+++ b/app/d3/multi-line-chart.js
@@ -206,12 +206,12 @@ angular.module('katGui.d3')
             };
 
             scope.removeSensorFunction = function(sensorName) {
-                var existingDataLine = _.findWhere(scope.nestedData, {
+                var index = _.findIndex(scope.nestedData, {
                     key: sensorName.replace(/\./g, '_')
                 });
-                if (existingDataLine) {
-                    scope.nestedData.splice(scope.nestedData.indexOf(existingDataLine), 1);
-                    d3.select("." + existingDataLine.key + "-tooltip").remove();
+                if (index > -1) {
+                    scope.nestedData.splice(index, 1);
+                    d3.select("." + sensorName + "-tooltip").remove();
                     drawValues();
                 }
             };
@@ -547,7 +547,9 @@ angular.module('katGui.d3')
                 // DATA JOIN
                 // Join new data with old elements, if any.
                 var focuslineGroups = focus.selectAll(".path-container")
-                    .data(scope.nestedData);
+                    .data(scope.nestedData, function(d) {
+                        return d.key;
+                    });
 
                 // EXIT
                 // remove stale elements.
@@ -592,7 +594,7 @@ angular.module('katGui.d3')
                         return d.key;
                     })
                     .attr("class", function(d) {
-                        return "value-line line " + d.key + " path-line";
+                        return "line value-line " + d.key + " path-line";
                     })
                     .attr("d", function(d) {
                         return line(d.values);
@@ -612,7 +614,7 @@ angular.module('katGui.d3')
                         return minline(d.values);
                     });
 
-                // // Create new elements as max line paths as needed.
+                // Create new elements as max line paths as needed.
                 pathContainer.append("path")
                     .attr("id", function(d) {
                         return d.key + 'maxLine';
@@ -626,7 +628,6 @@ angular.module('katGui.d3')
                         return maxline(d.values);
                     })
                     .attr("clip-path", "url(#clip)");
-
 
                 if (scope.mouseOverTooltip) {
                     scope.nestedData.forEach(function(data) {

--- a/app/d3/multi-line-chart.js
+++ b/app/d3/multi-line-chart.js
@@ -266,7 +266,8 @@ angular.module('katGui.d3')
                 d3.select(element[0]).select('svg').remove();
                 svg = d3.select(element[0]).append("svg")
                     .attr("width", width + margin.left + margin.right)
-                    .attr("height", height + margin.top + margin.bottom);
+                    .attr("height", height + margin.top + margin.bottom)
+                    .style("shape-rendering", "optimiseSpeed");
 
                 if (!scope.options.hideContextZoom) {
                     svg.append("defs").append("clipPath")
@@ -800,25 +801,24 @@ angular.module('katGui.d3')
 
             scope.downloadCsv = function(useUnixTimestamps) {
                 scope.nestedData.forEach(function(sensorValues, index) {
-                    var csvContent = "data:text/csv;charset=utf-8,update_time,value_time,status,value\n";
-                    var dataString = '';
-                    var valuesArray = [];
+                    var csvContent = ["timestamp,status,value"];
                     for (var i = 0; i < sensorValues.values.length; i++) {
+                        var dataString = '';
                         var sensorInfo = sensorValues.values[i];
                         if (useUnixTimestamps) {
                             dataString += (sensorInfo.sample_ts * 1000) + ',';
-                            dataString += (sensorInfo.value_ts * 1000) + ',';
                         } else {
                             dataString += moment.utc(sensorInfo.sample_ts).format('YYYY-MM-DD HH:mm:ss.SSS') + ',';
-                            dataString += moment.utc(sensorInfo.value_ts).format('YYYY-MM-DD HH:mm:ss.SSS') + ',';
                         }
                         dataString += sensorValues.values[i].status + ',';
-                        dataString += sensorValues.values[i].value + '\n';
+                        dataString += sensorValues.values[i].value;
+                        csvContent.push(dataString);
                     }
-                    var encodedUri = encodeURI(csvContent + dataString);
+                    var csvData = new Blob([csvContent.join('\r\n')], { type: 'text/csv' });
+                    var csvUrl = URL.createObjectURL(csvData);
                     var link = document.createElement("a");
-                    link.setAttribute("href", encodedUri);
-                    link.setAttribute("download", sensorValues.key + ".csv");
+                    link.href =  csvUrl;
+                    link.download = sensorValues.key + ".csv";
                     link.click();
                 });
             };

--- a/app/d3/multi-line-chart.js
+++ b/app/d3/multi-line-chart.js
@@ -598,36 +598,40 @@ angular.module('katGui.d3')
                     })
                     .attr("d", function(d) {
                         return line(d.values);
-                    });
-
-                // Create new elements as min line paths as needed.
-                pathContainer.append("path")
-                    .attr("id", function(d) {
-                        return d.key + 'minLine';
-                    })
-                    .attr("class", function(d) {
-                        return "line " + d.key + " path-line minline";
-                    })
-                    .style("opacity", "0.5")
-                    .style("stroke-dasharray", "20, 10")
-                    .attr("d", function(d) {
-                        return minline(d.values);
-                    });
-
-                // Create new elements as max line paths as needed.
-                pathContainer.append("path")
-                    .attr("id", function(d) {
-                        return d.key + 'maxLine';
-                    })
-                    .attr("class", function(d) {
-                        return "line " + d.key + " path-line maxline";
-                    })
-                    .style("opacity", "0.5")
-                    .style("stroke-dasharray", "20, 10")
-                    .attr("d", function(d) {
-                        return maxline(d.values);
                     })
                     .attr("clip-path", "url(#clip)");
+
+                if (!scope.options.discreteSensors) {
+                    // Create new elements as min line paths as needed.
+                    pathContainer.append("path")
+                        .attr("id", function(d) {
+                            return d.key + 'minLine';
+                        })
+                        .attr("class", function(d) {
+                            return "line " + d.key + " path-line minline";
+                        })
+                        .style("opacity", "0.5")
+                        .style("stroke-dasharray", "20, 10")
+                        .attr("d", function(d) {
+                            return minline(d.values);
+                        })
+                        .attr("clip-path", "url(#clip)");
+
+                    // Create new elements as max line paths as needed.
+                    pathContainer.append("path")
+                        .attr("id", function(d) {
+                            return d.key + 'maxLine';
+                        })
+                        .attr("class", function(d) {
+                            return "line " + d.key + " path-line maxline";
+                        })
+                        .style("opacity", "0.5")
+                        .style("stroke-dasharray", "20, 10")
+                        .attr("d", function(d) {
+                            return maxline(d.values);
+                        })
+                        .attr("clip-path", "url(#clip)");
+                }
 
                 if (scope.mouseOverTooltip) {
                     scope.nestedData.forEach(function(data) {

--- a/app/login-form/login-form.html
+++ b/app/login-form/login-form.html
@@ -4,6 +4,9 @@
         <h1>KATGUI <b>{{$root.systemType? ' - ' + $root.systemType : ''}}</b></h1>
     </md-toolbar>
     <form ng-submit="vm.verify(vm.credentials, vm.loginAs)" style="padding-top: 24px;" flex name="form" layout="column" layout-align="center center" layout-padding md-theme="{{themePrimaryButtons}}">
+        <md-input-container md-no-float required ng-if="$root.devMode" class="long-input">
+            <input focus ng-model="$root.portalUrl" placeholder="Portal URL">
+        </md-input-container>
         <md-input-container md-no-float required class="long-input">
             <input focus ng-model="vm.credentials.username" placeholder="Email">
         </md-input-container>

--- a/app/login-form/login-form.html
+++ b/app/login-form/login-form.html
@@ -4,14 +4,33 @@
         <h1>KATGUI <b>{{$root.systemType? ' - ' + $root.systemType : ''}}</b></h1>
     </md-toolbar>
     <form ng-submit="vm.verify(vm.credentials, vm.loginAs)" style="padding-top: 24px;" flex name="form" layout="column" layout-align="center center" layout-padding md-theme="{{themePrimaryButtons}}">
-        <md-input-container md-no-float required ng-if="$root.devMode" class="long-input">
-            <input focus ng-model="$root.portalUrl" placeholder="Portal URL">
+        <md-input-container ng-if="$root.devMode" class="long-input">
+            <label>Development Mode: Portal URL</label>
+            <input focus required name="portalUrl" ng-model="$root.portalUrl" ng-blur="vm.portalUrlBlur()"/>
+            <div ng-messages="form.portalUrl.$error" role="alert">
+                <div ng-message-exp="['required']">
+                    You must enter a URL to connect to when in development mode.
+                </div>
+            </div>
+        </md-input-container>
+        <md-input-container md-no-float class="long-input">
+            <label>Email</label>
+            <input required focus ng-model="vm.credentials.username" minlength="5" ng-pattern="/^.+@.+\..+$/"
+                 name="email" type="email"/>
+            <div ng-messages="form.email.$error" role="alert">
+                <div ng-message-exp="['required', 'minlength', 'pattern']">
+                    You must enter a valid email address that is longer than 5 characters.
+                </div>
+            </div>
         </md-input-container>
         <md-input-container md-no-float required class="long-input">
-            <input focus ng-model="vm.credentials.username" placeholder="Email">
-        </md-input-container>
-        <md-input-container  md-no-float required class="long-input">
-            <input type="password" ng-model="vm.credentials.password" placeholder="Password">
+            <label>Password</label>
+            <input type="password" required ng-model="vm.credentials.password" name="password"/>
+            <div ng-messages="form.password.$error" role="alert">
+                <div ng-message-exp="['required']">
+                    The password field cannot be empty.
+                </div>
+            </div>
         </md-input-container>
         <div layout="row" layout-align="center center">
             <label style="margin: -8px 12px 0 0">Login as</label>

--- a/app/login-form/login-form.js
+++ b/app/login-form/login-form.js
@@ -16,14 +16,19 @@
 
         vm.verify = function () {
             if ($rootScope.devMode) {
-                if (!$rootScope.portalUrl.startsWith('http://')) {
-                    $rootScope.portalUrl = 'http://' + $rootScope.portalUrl;
-                }
                 $localStorage.devModePortalURL = $rootScope.portalUrl;
             }
             $localStorage.loginAs = vm.loginAs;
             $rootScope.credentials = vm.credentials;
             SessionService.verify(vm.credentials.username, vm.credentials.password, vm.loginAs);
+            $rootScope.getSystemConfig();
+        };
+
+        vm.portalUrlBlur = function () {
+            if ($rootScope.portalUrl.length > 0 && !$rootScope.portalUrl.startsWith('http://')) {
+                $rootScope.portalUrl = 'http://' + $rootScope.portalUrl;
+            }
+            $rootScope.getSystemConfig(true);
         };
 
         $rootScope.getSystemConfig();

--- a/app/login-form/login-form.js
+++ b/app/login-form/login-form.js
@@ -15,6 +15,12 @@
         };
 
         vm.verify = function () {
+            if ($rootScope.devMode) {
+                if (!$rootScope.portalUrl.startsWith('http://')) {
+                    $rootScope.portalUrl = 'http://' + $rootScope.portalUrl;
+                }
+                $localStorage.devModePortalURL = $rootScope.portalUrl;
+            }
             $localStorage.loginAs = vm.loginAs;
             $rootScope.credentials = vm.credentials;
             SessionService.verify(vm.credentials.username, vm.credentials.password, vm.loginAs);

--- a/app/sensor-graph/sensor-graph.js
+++ b/app/sensor-graph/sensor-graph.js
@@ -264,7 +264,9 @@
                     if (result.data instanceof Array) {
                         vm.sensorDataReceived(null, {value: result.data});
                     }
-                    vm.sensorNames.push(sensor);
+                    if (!angular.isDefined(_.findWhere(vm.sensorNames, {name: sensor.name}))) {
+                        vm.sensorNames.push(sensor);
+                    }
                     if (vm.liveData) {
                         vm.connectLiveFeed(sensor.name);
                     }

--- a/app/sensor-graph/sensor-graph.js
+++ b/app/sensor-graph/sensor-graph.js
@@ -317,7 +317,7 @@
             var elements = document.getElementsByClassName(chipName);
             for (var i = 0; i < elements.length; i++) {
                 if (elements[i].classList[0] === 'line') {
-                    angular.element(elements[i]).css('stroke-width', '1.5px');
+                    angular.element(elements[i]).css('stroke-width', '1.0px');
                 } else if (elements[i].classList[0] === 'dot') {
                     for (var k = 0; k < elements[i].childNodes.length; k++) {
                         elements[i].childNodes[k].setAttribute('r', '3');

--- a/app/sensor-graph/sensor-graph.js
+++ b/app/sensor-graph/sensor-graph.js
@@ -352,7 +352,7 @@
 
         vm.sensorDataReceived = function (event, sensor) {
 
-            var hasMinMax = (vm.intervalNum !== 1 || vm.intervalType !== 's') && !vm.searchDiscrete;
+            var hasMinMax = (parseInt(vm.intervalNum) !== 1 || vm.intervalType !== 's') && !vm.searchDiscrete;
 
             if (sensor.value && sensor.value instanceof Array) {
                 vm.waitingForSearchResult = false;
@@ -373,8 +373,15 @@
                     newSensorNames[sensorName] = {};
                 }
 
-                if (newData) {
-                    vm.redrawChart(newData, true);
+                if (newData.length > 0) {
+                    vm.redrawChart(newData, hasMinMax);
+                }
+
+                //there are not enough pixels on our screens to display such a graph for complex paths!
+                if (newData.length > 65000) {
+                    NotifyService.showSimpleDialog("Too many samples!",
+                        "There are too many samples in the data set to draw reliably (" + newData.length + " samples). " +
+                        "Please reduce the search window if the results are not visible. Alternatively, download the CSV data.");
                 }
             }
             else if (sensor.value) {

--- a/app/sensor-graph/sensor-graph.js
+++ b/app/sensor-graph/sensor-graph.js
@@ -376,13 +376,6 @@
                 if (newData.length > 0) {
                     vm.redrawChart(newData, hasMinMax);
                 }
-
-                //there are not enough pixels on our screens to display such a graph for complex paths!
-                if (newData.length > 65000) {
-                    NotifyService.showSimpleDialog("Too many samples!",
-                        "There are too many samples in the data set to draw reliably (" + newData.length + " samples). " +
-                        "Please reduce the search window if the results are not visible. Alternatively, download the CSV data.");
-                }
             }
             else if (sensor.value) {
                 var realSensorName = sensor.name.split(':')[1].replace(/\./g, '_').replace(/-/g, '_');

--- a/app/sensor-graph/sensor-graph.less
+++ b/app/sensor-graph/sensor-graph.less
@@ -33,7 +33,10 @@
 
 .line {
     fill: none !important;
-    stroke-width: 1.5px;
+    // if we set the stroke-width > 1px, we do not draw the lines properly
+    // when there is a LOT of datapoints. Not setting this also improves
+    // painting performance a lot
+    // stroke-width: 1.5px;
 }
 
 .dot {

--- a/app/services/config-service.js
+++ b/app/services/config-service.js
@@ -3,9 +3,12 @@
     angular.module('katGui.services')
         .service('ConfigService', ConfigService);
 
-    function ConfigService($mdDialog, $q, $http, SERVER_URL, StatusService, $rootScope, $log, $timeout) {
+    function ConfigService($mdDialog, $q, $http, StatusService, $rootScope, $log, $timeout) {
 
-        var urlBase = SERVER_URL + '/katconf';
+        function urlBase() {
+            return $rootScope.portalUrl? $rootScope.portalUrl + '/katconf' : '';
+        }
+
         var api = {};
         api.receptorHealthTree = {};
         api.receptorList = [];
@@ -18,7 +21,7 @@
 
         api.loadSensorGroups = function () {
             var deferred = $q.defer();
-            $http(createRequest('get', urlBase + '/sensor-groups'))
+            $http(createRequest('get', urlBase() + '/sensor-groups'))
                 .then(function (result) {
                     api.sensorGroups = result.data;
                     deferred.resolve(api.sensorGroups);
@@ -32,7 +35,7 @@
         api.loadAggregateSensorDetail = function () {
             var deferred = $q.defer();
             if (!api.aggregateSensorDetail) {
-                $http(createRequest('get', urlBase + '/aggregates'))
+                $http(createRequest('get', urlBase() + '/aggregates'))
                     .then(function (result) {
                         api.aggregateSensorDetail = result.data;
                         deferred.resolve(api.aggregateSensorDetail);
@@ -55,8 +58,8 @@
                 $timeout(function () {
                     deferred.resolve(api.systemConfig);
                 }, 1);
-            } else {
-                $http(createRequest('get', urlBase + '/system-config'))
+            } else if (urlBase()) {
+                $http(createRequest('get', urlBase() + '/system-config'))
                     .then(function (result) {
                         api.systemConfig = result.data;
                         deferred.resolve(api.systemConfig);
@@ -64,6 +67,10 @@
                         $log.error(message);
                         deferred.reject(message);
                     });
+            } else if (!urlBase() || urlBase().length === 0) {
+                $timeout(function () {
+                    deferred.reject("No portalUrl has been specified.");
+                }, 1);
             }
             return deferred.promise;
         };
@@ -75,7 +82,7 @@
                     deferred.resolve(api.productConfig);
                 });
             } else {
-                $http(createRequest('get', urlBase + '/array-config/product_conf'))
+                $http(createRequest('get', urlBase() + '/array-config/product_conf'))
                     .then(function (result) {
                         api.productConfig = result.data;
                         deferred.resolve(api.productConfig);
@@ -112,18 +119,18 @@
         };
 
         api.getStatusTreeForReceptor = function () {
-            return $http(createRequest('get', urlBase + '/statustrees/receptors_view/receptors'));
+            return $http(createRequest('get', urlBase() + '/statustrees/receptors_view/receptors'));
         };
 
         api.getStatusTreesForTop = function () {
-            return $http(createRequest('get', urlBase + '/statustrees/top_view'));
+            return $http(createRequest('get', urlBase() + '/statustrees/top_view'));
         };
 
         api.getReceptorList = function () {
             api.receptorList.splice(0, api.receptorList.length);
 
             var deferred = $q.defer();
-            $http(createRequest('get', urlBase + '/installed-config/receptors'))
+            $http(createRequest('get', urlBase() + '/installed-config/receptors'))
                 .then(function (result) {
                     result.data.forEach(function (item) {
                         api.receptorList.push(item);
@@ -138,57 +145,57 @@
         };
 
         api.getSiteLocation = function () {
-            return $http(createRequest('get', urlBase + '/array/position'));
+            return $http(createRequest('get', urlBase() + '/array/position'));
         };
 
         api.getSources = function () {
-            return $http(createRequest('get', urlBase + '/sources'));
+            return $http(createRequest('get', urlBase() + '/sources'));
         };
 
         api.getWindstowLimits = function () {
-            return $http(createRequest('get', urlBase + '/array/windstow'));
+            return $http(createRequest('get', urlBase() + '/array/windstow'));
         };
 
         api.getHorizonMask = function (receptorId) {
-            return $http(createRequest('get', urlBase + '/horizon-mask/' + receptorId));
+            return $http(createRequest('get', urlBase() + '/horizon-mask/' + receptorId));
         };
 
         api.getConfigFileContents = function (filePath) {
-            return $http(createRequest('get', urlBase + '/config-file/' + filePath));
+            return $http(createRequest('get', urlBase() + '/config-file/' + filePath));
         };
 
         api.getSourceCataloguesList = function () {
-            return $http(createRequest('get', urlBase + '/config-file/katconfig/user/catalogues'));
+            return $http(createRequest('get', urlBase() + '/config-file/katconfig/user/catalogues'));
         };
 
         api.getNoiseDiodeModelsList = function () {
-            return $http(createRequest('get', urlBase + '/config-file/katconfig/user/noise-diode-models'));
+            return $http(createRequest('get', urlBase() + '/config-file/katconfig/user/noise-diode-models'));
         };
 
         api.getDelayModelsList = function () {
-            return $http(createRequest('get', urlBase + '/config-file/katconfig/user/delay-models'));
+            return $http(createRequest('get', urlBase() + '/config-file/katconfig/user/delay-models'));
         };
 
         api.getPointingModelsList = function () {
-            return $http(createRequest('get', urlBase + '/config-file/katconfig/user/pointing-models'));
+            return $http(createRequest('get', urlBase() + '/config-file/katconfig/user/pointing-models'));
         };
 
         api.getCam2SpeadList = function () {
-            return $http(createRequest('get', urlBase + '/config-file/katconfig/user/cam2spead'));
+            return $http(createRequest('get', urlBase() + '/config-file/katconfig/user/cam2spead'));
         };
 
         api.getCorrelatorsList = function () {
-            return $http(createRequest('get', urlBase + '/config-file/katconfig/user/correlators'));
+            return $http(createRequest('get', urlBase() + '/config-file/katconfig/user/correlators'));
         };
 
         api.getApodForDate = function (date) {
             var formatedDate = moment(date).format('YYYY/MM/DD');
-            return $http(createRequest('get', urlBase + '/apod/' + formatedDate));
+            return $http(createRequest('get', urlBase() + '/apod/' + formatedDate));
         };
 
         api.checkOutOfDateVersion = function () {
             if (document.katguiBuildDate) {
-                $http(createRequest('get', urlBase + '/katgui-version')).then(function (result) {
+                $http(createRequest('get', urlBase() + '/katgui-version')).then(function (result) {
                     var cachedBuildDate = new Date(document.katguiBuildDate);
                     var latestBuildDate = new Date(parseInt(result.data.buildDate));
                     if (cachedBuildDate < latestBuildDate) {

--- a/app/services/config-service.js
+++ b/app/services/config-service.js
@@ -3,7 +3,7 @@
     angular.module('katGui.services')
         .service('ConfigService', ConfigService);
 
-    function ConfigService($mdDialog, $q, $http, StatusService, $rootScope, $log, $timeout) {
+    function ConfigService($mdDialog, $q, $http, StatusService, $rootScope, $log, $timeout, KatGuiUtil) {
 
         function urlBase() {
             return $rootScope.portalUrl? $rootScope.portalUrl + '/katconf' : '';
@@ -52,13 +52,13 @@
             return deferred.promise;
         };
 
-        api.getSystemConfig = function () {
+        api.getSystemConfig = function (forceConfig) {
             var deferred = $q.defer();
-            if (api.systemConfig) {
+            if (api.systemConfig && !forceConfig) {
                 $timeout(function () {
                     deferred.resolve(api.systemConfig);
                 }, 1);
-            } else if (urlBase()) {
+            } else if (urlBase() && KatGuiUtil.isValidURL(urlBase())) {
                 $http(createRequest('get', urlBase() + '/system-config'))
                     .then(function (result) {
                         api.systemConfig = result.data;
@@ -67,9 +67,9 @@
                         $log.error(message);
                         deferred.reject(message);
                     });
-            } else if (!urlBase() || urlBase().length === 0) {
+            } else {
                 $timeout(function () {
-                    deferred.reject("No portalUrl has been specified.");
+                    deferred.reject("No valid portalUrl has been specified.");
                 }, 1);
             }
             return deferred.promise;

--- a/app/services/control-service.js
+++ b/app/services/control-service.js
@@ -1,84 +1,86 @@
 (function () {
 
     angular.module('katGui.services')
-        .constant('SERVER_URL', window.location.host === 'localhost:8000' ? 'http://monctl.devf.camlab.kat.ac.za' : window.location.origin)
         .service('ControlService', ControlService);
 
-    function ControlService($rootScope, $http, SERVER_URL, NotifyService, KatGuiUtil) {
+    function ControlService($rootScope, $http, NotifyService, KatGuiUtil) {
 
-        var urlBase = SERVER_URL + '/katcontrol';
+        function urlBase() {
+            return $rootScope.portalUrl? $rootScope.portalUrl + '/katcontrol' : '';
+        }
+
         var api = {};
 
         api.stowAll = function () {
-            return $http(createRequest('post', urlBase + '/receptors/stow-all'));
+            return $http(createRequest('post', urlBase() + '/receptors/stow-all'));
         };
 
         api.inhibitAll = function () {
-            return $http(createRequest('post', urlBase + '/receptors/inhibit-all'));
+            return $http(createRequest('post', urlBase() + '/receptors/inhibit-all'));
         };
 
         api.stopAll = function () {
-            return $http(createRequest('post', urlBase + '/receptors/stop-all'));
+            return $http(createRequest('post', urlBase() + '/receptors/stop-all'));
         };
 
         api.resumeOperations = function () {
-            return $http(createRequest('post', urlBase + '/receptors/resume-all'));
+            return $http(createRequest('post', urlBase() + '/receptors/resume-all'));
         };
 
         api.floodlightsOn = function (onOff) {
-            return $http(createRequest('post', urlBase + '/vds/floodlights/' + onOff));
+            return $http(createRequest('post', urlBase() + '/vds/floodlights/' + onOff));
         };
 
         api.shutdownComputing = function () {
-            return $http(createRequest('post', urlBase + '/system/shutdown-computing'));
+            return $http(createRequest('post', urlBase() + '/system/shutdown-computing'));
         };
 
         api.shutdownSPCorr = function () {
-            return $http(createRequest('post', urlBase + '/system/shutdown-sp-corr'));
+            return $http(createRequest('post', urlBase() + '/system/shutdown-sp-corr'));
         };
 
         api.acknowledgeAlarm = function (alarmName) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/alarms/' + alarmName + '/acknowledge')));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/alarms/' + alarmName + '/acknowledge')));
         };
 
         api.addKnownAlarm = function (alarmName) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/alarms/' + alarmName + '/known')));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/alarms/' + alarmName + '/known')));
         };
 
         api.cancelKnownAlarm = function (alarmName) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/alarms/' + alarmName + '/cancel-known')));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/alarms/' + alarmName + '/cancel-known')));
         };
 
         api.clearAlarm = function (alarmName) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/alarms/' + alarmName + '/clear')));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/alarms/' + alarmName + '/clear')));
         };
 
         api.startProcess = function (nodeMan, processName) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/process/' + nodeMan + '/' + processName + '/start')));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/process/' + nodeMan + '/' + processName + '/start')));
         };
 
         api.restartProcess = function (nodeMan, processName) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/process/' + nodeMan + '/' + processName + '/restart')));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/process/' + nodeMan + '/' + processName + '/restart')));
         };
 
         api.killProcess = function (nodeMan, processName) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/process/' + nodeMan + '/' + processName + '/kill')));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/process/' + nodeMan + '/' + processName + '/kill')));
         };
 
         api.stopProcess = function (nodeMan, processName) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/process/' + nodeMan + '/' + processName + '/stop')));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/process/' + nodeMan + '/' + processName + '/stop')));
         };
 
         api.toggleKATCPMessageDevices = function (resource, newValue) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/logging/' + resource + '/katcpmsgs-devices/' + newValue)));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/logging/' + resource + '/katcpmsgs-devices/' + newValue)));
         };
 
         api.toggleKATCPMessageProxy = function (resource, newValue) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/logging/' + resource + '/katcpmsgs-proxy/' + newValue)));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/logging/' + resource + '/katcpmsgs-proxy/' + newValue)));
         };
 
         api.tailProcess = function (nodeman, process, lines) {
-            return $http(createRequest('get', urlBase + '/tail/process/' + nodeman + '/' + process + '/' + lines));
+            return $http(createRequest('get', urlBase() + '/tail/process/' + nodeman + '/' + process + '/' + lines));
         };
 
         api.handleRequestResponse = function (request) {

--- a/app/services/data-service.js
+++ b/app/services/data-service.js
@@ -3,13 +3,15 @@
     angular.module('katGui.services')
         .service('DataService', DataService);
 
-    function DataService($http, SERVER_URL) {
+    function DataService($http, $rootScope) {
 
-        var urlBase = SERVER_URL + '/katstore/';
+        function urlBase() {
+            return $rootScope.portalUrl? $rootScope.portalUrl + '/katstore/' : '';
+        }
         var api = {};
 
         api.sensorsInfo = function (sensorNames, type, limit) {
-            var requestStr = urlBase +
+            var requestStr = urlBase() +
                 'sensors?sensors=' + sensorNames +
                 '&sensor_type=' + type +
                 '&limit=' + limit;
@@ -17,7 +19,7 @@
         };
 
         api.sensorData = function (namespace, sensorName, startDate, endDate, limit, interval) {
-            var requestStr = urlBase +
+            var requestStr = urlBase() +
                 'samples?sensor=' + sensorName +
                 '&start=' + startDate +
                 '&end=' + endDate +
@@ -50,7 +52,7 @@
 
             var req = {
                 method: 'post',
-                url: urlBase + 'samples',
+                url: urlBase() + 'samples',
                 headers: {},
                 data: data
             };
@@ -59,7 +61,7 @@
         };
 
         api.sampleValueDuration = function (sensorNames, startDate, endDate) {
-            var requestStr = urlBase +
+            var requestStr = urlBase() +
                 'sample-value-duration?sensors=' + sensorNames +
                 '&start=' + startDate +
                 '&end=' + endDate +

--- a/app/services/data-service.js
+++ b/app/services/data-service.js
@@ -24,6 +24,7 @@
                 '&start=' + startDate +
                 '&end=' + endDate +
                 '&limit=' + limit +
+                '&results_in_chunks=' + 0 +
                 '&time_type=ms';
 
             if (namespace) {

--- a/app/services/monitor-service.js
+++ b/app/services/monitor-service.js
@@ -3,11 +3,13 @@
     angular.module('katGui.services')
         .service('MonitorService', MonitorService);
 
-    function MonitorService(SERVER_URL, KatGuiUtil, $timeout, StatusService, AlarmsService, ObsSchedService, $interval,
+    function MonitorService(KatGuiUtil, $timeout, StatusService, AlarmsService, ObsSchedService, $interval,
                             $rootScope, $q, $log, ReceptorStateService, NotifyService, UserLogService, ConfigService,
                             SessionService, SensorsService) {
 
-        var urlBase = SERVER_URL + '/katmonitor';
+        function urlBase() {
+            return $rootScope.portalUrl? $rootScope.portalUrl + '/katmonitor' : '';
+        }
         var api = {};
         api.deferredMap = {};
         api.connection = null;
@@ -204,7 +206,7 @@
             api.deferredMap['connectDefer'] = $q.defer();
             if (!api.connection) {
                 $log.info('Monitor Connecting...');
-                api.connection = new SockJS(urlBase + '/portal');
+                api.connection = new SockJS(urlBase() + '/portal');
                 api.connection.onopen = api.onSockJSOpen;
                 api.connection.onmessage = api.onSockJSMessage;
                 api.connection.onclose = api.onSockJSClose;

--- a/app/services/notify-service.js
+++ b/app/services/notify-service.js
@@ -11,6 +11,10 @@
 
         api.showSimpleToast = function (message) {
             // $mdToast.hide();
+            if (!message || message.length === 0) {
+                $log.error('Attempting to show empty toast message - aborting.');
+                return;
+            }
             var simpleToast = $mdToast.simple()
                 .content(message)
                 .highlightAction(true)

--- a/app/services/obs-sched-service.js
+++ b/app/services/obs-sched-service.js
@@ -3,11 +3,13 @@
     angular.module('katGui.services')
         .service('ObsSchedService', ObsSchedService);
 
-    function ObsSchedService($rootScope, $http, SERVER_URL, ConfigService, KatGuiUtil,
+    function ObsSchedService($rootScope, $http, ConfigService, KatGuiUtil,
                              UserLogService, $log, $q, $mdDialog, NotifyService,
                              $timeout, $interval, $localStorage) {
 
-        var urlBase = SERVER_URL + '/katcontrol';
+        function urlBase() {
+            return $rootScope.portalUrl? $rootScope.portalUrl + '/katcontrol' : '';
+        }
         var api = {};
         if (!$localStorage.lastKnownSubarrayConfig) {
             $localStorage.lastKnownSubarrayConfig = {};
@@ -64,7 +66,7 @@
         };
 
         api.markResourceFaulty = function (resource, faulty) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/resource/' + resource + '/faulty/' + faulty)));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/resource/' + resource + '/faulty/' + faulty)));
             var tags = [];
             tags.push(_.find(UserLogService.tags, function (item) {return item.name === 'status'; }));
             var tagResource = _.find(UserLogService.tags, function (item) {return item.name === resource; });
@@ -85,7 +87,7 @@
         };
 
         api.markResourceInMaintenance = function (resource, maintenance) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/resource/' + resource + '/maintenance/' + maintenance)));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/resource/' + resource + '/maintenance/' + maintenance)));
             var tags = [];
             tags.push(_.find(UserLogService.tags, function (item) {return item.name === 'maintenance'; }));
             var tagResource = _.find(UserLogService.tags, function (item) {return item.name === resource; });
@@ -106,31 +108,31 @@
         };
 
         api.restartMaintenanceDevice = function (sub_nr, resource, device) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/subarray/' + sub_nr + '/resource/' + resource + '/device/' + device + '/restart')));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/subarray/' + sub_nr + '/resource/' + resource + '/device/' + device + '/restart')));
         };
 
         api.listResourceMaintenanceDevices = function (resource) {
-            return $http(createRequest('get',  urlBase + '/resource/' + resource + '/maintenance-device-list'));
+            return $http(createRequest('get',  urlBase() + '/resource/' + resource + '/maintenance-device-list'));
         };
 
         api.deleteScheduleDraft = function (id) {
-            return $http(createRequest('post', urlBase + '/sb/' + id + '/delete'));
+            return $http(createRequest('post', urlBase() + '/sb/' + id + '/delete'));
         };
 
         api.scheduleDraft = function (sub_nr, id) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/sb/' + sub_nr + '/' + id + '/schedule')));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/sb/' + sub_nr + '/' + id + '/schedule')));
         };
 
         api.scheduleToDraft = function (sub_nr, id_code) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/sb/' + sub_nr + '/' + id_code + '/to-draft')));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/sb/' + sub_nr + '/' + id_code + '/to-draft')));
         };
 
         api.scheduleToComplete = function (sub_nr, id_code) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/sb/' + sub_nr + '/' + id_code + '/complete')));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/sb/' + sub_nr + '/' + id_code + '/complete')));
         };
 
         api.setSchedulePriority = function (id_code, priority) {
-            $http(createRequest('post', urlBase + '/sb/' + id_code + '/priority/' + priority))
+            $http(createRequest('post', urlBase() + '/sb/' + id_code + '/priority/' + priority))
                 .then(function (result) {
                     NotifyService.showSimpleToast('Set Priority ' + id_code + ' to ' + priority);
                 }, function (error) {
@@ -139,27 +141,27 @@
         };
 
         api.verifyScheduleBlock = function (sub_nr, id_code) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/sb/' + sub_nr + '/' + id_code + '/verify')));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/sb/' + sub_nr + '/' + id_code + '/verify')));
         };
 
         api.executeSchedule = function (sub_nr, id_code) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/sb/' + sub_nr + '/' + id_code + '/execute')));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/sb/' + sub_nr + '/' + id_code + '/execute')));
         };
 
         api.stopSchedule = function (sub_nr, id_code) {
             NotifyService.showImportantConfirmDialog(null, 'Stop Executing Schedule', 'Are you sure you want to stop executing ' + id_code + '?', 'Yes', 'Cancel').then(function() {
-                api.handleRequestResponse($http(createRequest('post', urlBase + '/sb/' + sub_nr + '/' + id_code + '/stop')));
+                api.handleRequestResponse($http(createRequest('post', urlBase() + '/sb/' + sub_nr + '/' + id_code + '/stop')));
             }, function () {
                 NotifyService.showSimpleToast('Cancelled stop executing ' + id_code);
             });
         };
 
         api.cancelExecuteSchedule = function (sub_nr, id_code) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/sb/' + sub_nr + '/' + id_code + '/cancel-execute')));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/sb/' + sub_nr + '/' + id_code + '/cancel-execute')));
         };
 
         api.cloneSchedule = function (id_code) {
-            return $http(createRequest('post', urlBase + '/sb/' + id_code + '/clone'));
+            return $http(createRequest('post', urlBase() + '/sb/' + id_code + '/clone'));
         };
 
         api.cloneAndAssignSchedule = function (id_code, sub_nr) {
@@ -175,37 +177,37 @@
         };
 
         api.assignScheduleBlock = function (sub_nr, id_code) {
-            return api.handleRequestResponse($http(createRequest('post', urlBase + '/sb/' + sub_nr + '/' + id_code + '/assign')), true);
+            return api.handleRequestResponse($http(createRequest('post', urlBase() + '/sb/' + sub_nr + '/' + id_code + '/assign')), true);
         };
 
         api.unassignScheduleBlock = function (sub_nr, id_code) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/sb/' + sub_nr + '/' + id_code + '/unassign')));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/sb/' + sub_nr + '/' + id_code + '/unassign')));
         };
 
         api.assignResourcesToSubarray = function (sub_nr, resources) {
-            return api.handleRequestResponse($http(createRequest('post', urlBase + '/subarray/' + sub_nr + '/assign-resource/' + resources)), true);
+            return api.handleRequestResponse($http(createRequest('post', urlBase() + '/subarray/' + sub_nr + '/assign-resource/' + resources)), true);
         };
 
         api.unassignResourcesFromSubarray = function (sub_nr, resources) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/subarray/' + sub_nr + '/unassign-resource/' + resources)));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/subarray/' + sub_nr + '/unassign-resource/' + resources)));
         };
 
         api.activateSubarray = function (sub_nr) {
-            return $http(createRequest('post', urlBase + '/subarray/' + sub_nr + '/activate'), true);
+            return $http(createRequest('post', urlBase() + '/subarray/' + sub_nr + '/activate'), true);
         };
 
         api.setSubarrayMaintenance = function (sub_nr, maintenance) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/subarray/' + sub_nr + '/maintenance/' + maintenance)));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/subarray/' + sub_nr + '/maintenance/' + maintenance)));
         };
 
         api.freeSubarray = function (sub_nr) {
-            return api.handleRequestResponse($http(createRequest('post', urlBase + '/subarray/' + sub_nr + '/free')), true);
+            return api.handleRequestResponse($http(createRequest('post', urlBase() + '/subarray/' + sub_nr + '/free')), true);
         };
 
         api.getScheduleBlocks = function () {
             //TODO smoothly combine the existing list with the new list so that there isnt a screen flicker
             api.scheduleDraftData.splice(0, api.scheduleDraftData.length);
-            $http(createRequest('get', urlBase + '/sb'))
+            $http(createRequest('get', urlBase() + '/sb'))
                 .then(function (result) {
                     var jsonResult = JSON.parse(result.data.result);
                     for (var i in jsonResult) {
@@ -220,7 +222,7 @@
 
         api.getScheduleBlockDetails = function (idCodes) {
             return $http(createRequest('post',
-                urlBase + '/sb/details',
+                urlBase() + '/sb/details',
                 {
                     id_codes: idCodes.join(',')
                 }));
@@ -228,7 +230,7 @@
 
         api.getScheduledScheduleBlocks = function () {
             var deferred = $q.defer();
-            $http(createRequest('get', urlBase + '/sb/scheduled'))
+            $http(createRequest('get', urlBase() + '/sb/scheduled'))
                 .then(function (result) {
                     var jsonResult = JSON.parse(result.data.result);
                     var newScheduleDataIdCodes = [];
@@ -268,7 +270,7 @@
         api.getCompletedScheduleBlocks = function (sub_nr, max_nr) {
             //TODO smoothly combine the existing list with the new list so that there isnt a screen flicker
             api.scheduleCompletedData.splice(0, api.scheduleCompletedData.length);
-            $http(createRequest('get', urlBase + '/sb/completed/' + sub_nr + '/' + max_nr))
+            $http(createRequest('get', urlBase() + '/sb/completed/' + sub_nr + '/' + max_nr))
                 .then(function (result) {
                     var jsonResult = JSON.parse(result.data.result);
                     for (var i in jsonResult) {
@@ -280,11 +282,11 @@
         };
 
         api.setSchedulerModeForSubarray = function (sub_nr, mode) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/subarray/' + sub_nr + '/sched-mode/' + mode)));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/subarray/' + sub_nr + '/sched-mode/' + mode)));
         };
 
         api.updateScheduleDraft = function (scheduleBlockDraft) {
-            return $http(createRequest('post', urlBase + '/sb/' + scheduleBlockDraft.id_code, {
+            return $http(createRequest('post', urlBase() + '/sb/' + scheduleBlockDraft.id_code, {
                 id_code: scheduleBlockDraft.id_code,
                 type: scheduleBlockDraft.type,
                 instruction_set: scheduleBlockDraft.instruction_set,
@@ -465,7 +467,7 @@
 
         api.listConfigLabels = function () {
             api.configLabels.splice(0, api.configLabels.length);
-            $http(createRequest('get', urlBase + '/config-labels'))
+            $http(createRequest('get', urlBase() + '/config-labels'))
                 .then(function (result) {
                     var configLabels = JSON.parse(result.data);
                     configLabels.forEach(function (item) {
@@ -477,19 +479,19 @@
         };
 
         api.setConfigLabel = function (sub_nr, config_label) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/config-labels/' + sub_nr + '/' + config_label)));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/config-labels/' + sub_nr + '/' + config_label)));
         };
 
         api.setBand = function (sub_nr, band) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/bands/' + sub_nr + '/' + band)));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/bands/' + sub_nr + '/' + band)));
         };
 
         api.setProduct = function (sub_nr, product) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/products/' + sub_nr + '/' + product)));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/products/' + sub_nr + '/' + product)));
         };
 
         api.delegateControl = function (sub_nr, userName) {
-            api.handleRequestResponse($http(createRequest('post', urlBase + '/subarray/' + sub_nr + '/delegate-control/' + userName)));
+            api.handleRequestResponse($http(createRequest('post', urlBase() + '/subarray/' + sub_nr + '/delegate-control/' + userName)));
         };
 
         api.viewTaskLogForSBIdCode = function (id_code, mode) {
@@ -558,7 +560,7 @@
 
         api.listResourceTemplates = function () {
             api.resourceTemplates.splice(0, api.resourceTemplates.length);
-            $http.get(urlBase + '/subarray/template/list')
+            $http.get(urlBase() + '/subarray/template/list')
                 .then(function (result) {
                     result.data.forEach(function (item) {
                         api.resourceTemplates.push(item);
@@ -584,7 +586,7 @@
 
         api.addResourceTemplate = function (template) {
             $http(createRequest('post',
-                urlBase + '/subarray/template/add',
+                urlBase() + '/subarray/template/add',
                 {
                     name: template.name,
                     owner: $rootScope.currentUser.email,
@@ -602,7 +604,7 @@
 
         api.modifyResourceTemplate = function (template) {
             $http(createRequest('post',
-                urlBase + '/subarray/template/modify/' + template.id,
+                urlBase() + '/subarray/template/modify/' + template.id,
                 {
                     name: template.name,
                     owner: $rootScope.currentUser.email,

--- a/app/services/sensors-service.js
+++ b/app/services/sensors-service.js
@@ -3,10 +3,12 @@
     angular.module('katGui.services')
         .service('SensorsService', SensorsService);
 
-    function SensorsService($rootScope, SERVER_URL, KatGuiUtil, $timeout, $q, $interval, $log, $http,
+    function SensorsService($rootScope, KatGuiUtil, $timeout, $q, $interval, $log, $http,
                             ConfigService) {
 
-        var urlBase = SERVER_URL + '/katmonitor';
+        function urlBase() {
+            return $rootScope.portalUrl? $rootScope.portalUrl + '/katmonitor' : '';
+        }
         var api = {};
         api.connection = null;
         api.deferredMap = {};
@@ -141,7 +143,7 @@
             } else {
                 api.guid = KatGuiUtil.generateUUID();
                 $log.info('Sensors Connecting...');
-                api.connection = new SockJS(urlBase + '/client');
+                api.connection = new SockJS(urlBase() + '/client');
                 api.connection.onopen = api.onSockJSOpen;
                 api.connection.onmessage = api.onSockJSMessage;
                 api.connection.onclose = api.onSockJSClose;
@@ -203,7 +205,7 @@
 
         api.listResources = function () {
             var deferred = $q.defer();
-            $http.get(urlBase + '/resource')
+            $http.get(urlBase() + '/resource')
                 .then(function (result) {
                     for (var i in result.data) {
                         for (var node in ConfigService.systemConfig['katconn:resources']) {
@@ -253,7 +255,7 @@
 
         api.listResourceSensors = function (resourceName) {
             var deferred = $q.defer();
-            $http.get(urlBase + '/resource/' + resourceName + '/sensors')
+            $http.get(urlBase() + '/resource/' + resourceName + '/sensors')
                 .then(function (result) {
                     api.resources[resourceName].sensorsList = [];
                     for (var i in result.data) {
@@ -278,7 +280,7 @@
 
         api.listSensors = function (filter) {
             var deferred = $q.defer();
-            $http.post(urlBase + '/sensor-list', {filter: filter})
+            $http.post(urlBase() + '/sensor-list', {filter: filter})
                 .then(function (result) {
                     deferred.resolve(result);
                 }, function (result) {

--- a/app/services/session-service.js
+++ b/app/services/session-service.js
@@ -49,7 +49,7 @@
                         if (payload.req_role === 'lead_operator' &&
                             payload.current_lo &&
                             payload.current_lo !== payload.requester) {
-                            confirmRole(result.data.confirmation_token, payload);
+                            confirmRole(result.data.session_id, payload);
                         } else {
                             api.login(payload.session_id);
                         }
@@ -161,7 +161,7 @@
                     if (payload.req_role === 'lead_operator' &&
                         payload.current_lo &&
                         payload.current_lo !== payload.requester) {
-                        confirmRole(result.data.confirmation_token, payload, true);
+                        confirmRole(result.data.session_id, payload);
                     } else {
                         api.login(payload.session_id);
                     }
@@ -219,7 +219,7 @@
                         };
 
                         $scope.cancel = function () {
-                            session_id = null;
+                            api.login(readonly_session_id);
                             $mdDialog.hide();
                         };
                     },

--- a/app/services/session-service.js
+++ b/app/services/session-service.js
@@ -223,21 +223,22 @@
                             $mdDialog.hide();
                         };
                     },
-                    template: '<md-dialog md-theme="{{$root.themePrimary}}" class="md-whiteframe-z1">' +
-                        '<md-toolbar class="md-toolbar-tools md-whiteframe-z1">Confirm login as {{$root.rolesMap[requested_role]}}</md-toolbar>' +
-                        '  <md-dialog-content class="md-padding" layout="column">' +
-                        '   <p><b>{{current_lo ? current_lo : "No one"}}</b> is the current Lead Operator.</p>' +
-                        '   <p ng-show="current_lo">If you proceed <b>{{current_lo}}</b> will be demoted to the Monitor Role.</p>' +
-                        '  </md-dialog-content>' +
-                        '  <md-dialog-actions layout="row" md-theme="{{$root.themePrimaryButtons}}">' +
-                        '    <md-button ng-click="cancel()" class="md-primary md-raised">' +
-                        '      Cancel' +
-                        '    </md-button>' +
-                        '    <md-button ng-click="proceed()" class="md-primary md-raised">' +
-                        '      Proceed' +
-                        '    </md-button>' +
-                        '  </md-dialog-actions>' +
-                        '</md-dialog>'
+                    template: [
+                        '<md-dialog md-theme="{{$root.themePrimary}}" class="md-whiteframe-z1">',
+                            '<md-toolbar class="md-toolbar-tools md-whiteframe-z1">Confirm login as {{$root.rolesMap[requested_role]}}</md-toolbar>',
+                            '<md-dialog-content class="md-padding" layout="column">',
+                                '<p><b>{{current_lo ? current_lo : "No one"}}</b> is the current Lead Operator.</p>',
+                                '<p ng-show="current_lo">If you proceed <b>{{current_lo}}</b> will be demoted to the Monitor Role.</p>',
+                            '</md-dialog-content>',
+                            '<md-dialog-actions layout="row" md-theme="{{$root.themePrimaryButtons}}">',
+                                '<md-button ng-click="cancel()" class="md-primary md-raised">',
+                                    'Login As Monitor Only',
+                                '</md-button>',
+                                '<md-button ng-click="proceed()" class="md-primary md-raised">',
+                                    'Login As Lead Operator',
+                                '</md-button>',
+                            '</md-dialog-actions>',
+                        '</md-dialog>'].join('')
                     });
         }
 

--- a/app/services/user-service.js
+++ b/app/services/user-service.js
@@ -3,17 +3,20 @@
     angular.module('katGui.services')
         .service('UserService', UserService);
 
-    function UserService($http, $q, SERVER_URL, $rootScope, $log, NotifyService) {
+    function UserService($http, $q, $rootScope, $log, NotifyService) {
+
+        function urlBase() {
+            return $rootScope.portalUrl? $rootScope.portalUrl + '/katauth' : '';
+        }
 
         var api = {};
-        api.urlBase = SERVER_URL + '/katauth';
         api.users = [];
 
         api.listUsers = function () {
 
             var def = $q.defer();
 
-            $http(createRequest('get', api.urlBase + '/user/list')).then(
+            $http(createRequest('get', urlBase() + '/user/list')).then(
                 function (result) {
 
                     if (result && result.data) {
@@ -35,7 +38,7 @@
 
         api.createUser = function (user) {
             $http(createRequest('post',
-                api.urlBase + '/user/add',
+                urlBase() + '/user/add',
                 {
                     name: user.name,
                     email: user.email,
@@ -56,7 +59,7 @@
         };
 
         api.updateUser = function (user) {
-            $http(createRequest('post', api.urlBase + '/user/modify/' + user.id,
+            $http(createRequest('post', urlBase() + '/user/modify/' + user.id,
                 {
                     name: user.name,
                     email: user.email,
@@ -76,7 +79,7 @@
 
         api.resetPassword = function (user, passwordHash) {
             return $http(createRequest('post',
-                api.urlBase + '/user/reset/' + user.id,
+                urlBase() + '/user/reset/' + user.id,
                 {'password': passwordHash}));
         };
 

--- a/app/services/userlog-service.js
+++ b/app/services/userlog-service.js
@@ -3,10 +3,13 @@
     angular.module('katGui.services')
         .service('UserLogService', UserLogService);
 
-    function UserLogService($http, $q, $rootScope, $window, $log, $filter, $timeout, SERVER_URL, NotifyService, $mdDialog, $sce) {
+    function UserLogService($http, $q, $rootScope, $window, $log, $filter, $timeout, NotifyService, $mdDialog, $sce) {
+
+        function urlBase() {
+            return $rootScope.portalUrl? $rootScope.portalUrl + '/katcontrol' : '';
+        }
 
         var api = {};
-        api.urlBase = SERVER_URL + '/katcontrol';
         api.userlogs = [];
         api.tags = [];
         api.tagsMap = {};
@@ -34,7 +37,7 @@
         api.listUserLogsForTimeRange = function (start, end) {
             var deferred = $q.defer();
             var query = '?start_time=' + start + '&end_time=' + end;
-            $http(createRequest('get', api.urlBase + '/userlogs/query' + query)).then(
+            $http(createRequest('get', urlBase() + '/userlogs/query' + query)).then(
                 function (result) {
                     if (result && result.data) {
                         result.data.forEach(function (userlog) {
@@ -54,7 +57,7 @@
 
         api.listTags = function () {
             var deferred = $q.defer();
-            $http(createRequest('get', api.urlBase + '/tags')).then(
+            $http(createRequest('get', urlBase() + '/tags')).then(
                 function (result) {
                     if (result && result.data) {
                         api.tags.splice(0, api.tags.length);
@@ -76,7 +79,7 @@
 
         api.listTaxonomies = function () {
             var deferred = $q.defer();
-            $http(createRequest('get', api.urlBase + '/taxonomies')).then(
+            $http(createRequest('get', urlBase() + '/taxonomies')).then(
                 function (result) {
                     if (result && result.data) {
                         api.taxonomies.splice(0, api.taxonomies.length);
@@ -98,7 +101,7 @@
         api.queryUserLogs = function (query) {
             var query_uri = encodeURI(query);
             var defer = $q.defer();
-            $http(createRequest('get', api.urlBase + '/userlogs/query' + query_uri)).then(
+            $http(createRequest('get', urlBase() + '/userlogs/query' + query_uri)).then(
                 function (result) {
                     defer.resolve(result);
                 }, function (result) {
@@ -111,7 +114,7 @@
         api.queryActivityLogs = function (query) {
             var query_uri = encodeURI(query);
             var defer = $q.defer();
-            $http(createRequest('get', api.urlBase + '/userlogs/activity' + query_uri)).then(
+            $http(createRequest('get', urlBase() + '/userlogs/activity' + query_uri)).then(
                 function (result) {
                     defer.resolve(result);
                 }, function (error) {
@@ -123,7 +126,7 @@
 
         api.getLogFiles = function () {
             var deferred = $q.defer();
-            $http(createRequest('get', api.urlBase + '/log-files')).then(
+            $http(createRequest('get', urlBase() + '/log-files')).then(
                 function (result) {
                     if (result && result.data) {
                         api.logFiles.splice(0, api.logFiles.length);
@@ -149,7 +152,7 @@
                 start_time: start_time,
                 end_time: end_time
             };
-            $http(createRequest('post', api.urlBase + '/search-logs', searchQuery)).then(
+            $http(createRequest('post', urlBase() + '/search-logs', searchQuery)).then(
                 function (result) {
                     defer.resolve(result);
                 }, function (error) {
@@ -172,7 +175,7 @@
                     'Authorization': 'CustomJWT ' + $rootScope.jwt
                 }
             };
-            $http.post(api.urlBase + '/userlogs/' + userlog_id + '/attachments', formData, options).then(
+            $http.post(urlBase() + '/userlogs/' + userlog_id + '/attachments', formData, options).then(
                 function (result) {
                     defer.resolve(result);
                     NotifyService.showSimpleToast("Uploaded files successfully.");
@@ -191,7 +194,7 @@
                 },
                 responseType: 'blob'
             };
-            $http.get(api.urlBase + '/userlogs/' + userlog_id + '/attachments/' + file_name, options).then(
+            $http.get(urlBase() + '/userlogs/' + userlog_id + '/attachments/' + file_name, options).then(
                 function (result) {
                     var blob = result.data;
                     var url = $window.URL || $window.webkitURL;
@@ -202,7 +205,7 @@
                     downloadLink[0].click();
                     url.revokeObjectURL(file_url);
                 }, function () {
-                    $log.error(api.urlBase + '/userlogs/get/attach');
+                    $log.error(urlBase() + '/userlogs/get/attach');
                 });
         };
 
@@ -215,7 +218,7 @@
                 content: log.content,
                 tag_ids: log.tag_ids
             };
-            $http(createRequest('post', api.urlBase + '/userlogs', newUserLog)).then(
+            $http(createRequest('post', urlBase() + '/userlogs', newUserLog)).then(
                 function (result) {
                     NotifyService.showSimpleToast("Log Created. ");
                     defer.resolve(result);
@@ -235,7 +238,7 @@
                 tag_ids: ulog.tag_ids,
                 metadata: ulog.metadata
             };
-            $http(createRequest('post', api.urlBase + '/userlogs/' + ulog.id, modifiedUserLog)).then(
+            $http(createRequest('post', urlBase() + '/userlogs/' + ulog.id, modifiedUserLog)).then(
                 function (result) {
                     NotifyService.showSimpleToast("Edited userlog " + result.data.id);
                     defer.resolve(result);
@@ -253,7 +256,7 @@
                 slug: tag.slug,
                 activated: tag.activated
             };
-            $http(createRequest('post', api.urlBase + '/tags/modify/' + tag.id, modifiedTag)).then(
+            $http(createRequest('post', urlBase() + '/tags/modify/' + tag.id, modifiedTag)).then(
                 function (result) {
                     NotifyService.showSimpleToast("Modified tag " + tag.id + ".");
                     defer.resolve(result);
@@ -271,7 +274,7 @@
                 slug: tag.slug,
                 activated: tag.activated
             };
-            $http(createRequest('post', api.urlBase + '/tags/add', newTag)).then(
+            $http(createRequest('post', urlBase() + '/tags/add', newTag)).then(
                 function (result) {
                     tag.id = result.data.id;
                     tag.name = tag.name;

--- a/app/util/util.js
+++ b/app/util/util.js
@@ -349,7 +349,7 @@ function autoGrow() {
 /* istanbul ignore next */
 //be very sure you know what you are doing when you alter the below functions
 //they are not tested
-function katGuiUtil(SERVER_URL, $sce) {
+function katGuiUtil($rootScope, $sce) {
 
     this.generateUUID = function() {
         var d = new Date().getTime();
@@ -365,7 +365,7 @@ function katGuiUtil(SERVER_URL, $sce) {
         if (window.location.host !== 'localhost:8000') {
             window.open("http://" + window.location.hostname + ":" + port + "/" + path).focus();
         } else {
-            window.open(SERVER_URL + ":" + port + "/" + path).focus();
+            window.open($rootScope.portalUrl + ":" + port + "/" + path).focus();
         }
     };
 

--- a/app/video/video.js
+++ b/app/video/video.js
@@ -8,8 +8,11 @@
     function VideoCtrl($scope, $rootScope, $http, $log, $interval, $mdDialog, ControlService, SensorsService,
                        SERVER_URL, NotifyService, USER_ROLES, ConfigService, KatGuiUtil, $state) {
 
+        function urlBase() {
+           return $rootScope.portalUrl? $rootScope.portalUrl + '/katcontrol/vds' : '';
+        }
+
         var vm = this;
-        var urlBase = SERVER_URL + '/katcontrol/vds';
 
         ConfigService.getSystemConfig()
             .then(function (systemConfig) {
@@ -81,7 +84,7 @@
                         $scope.title = 'Set VDS Preset';
                         $scope.presetIDs = [];
                         for (var i = 0; i < 64; i++) {
-                            $http(createRequest('post', urlBase + '/presetset/'));
+                            $http(createRequest('post', urlBase() + '/presetset/'));
                             if (i < 10) {
                                 $scope.presetIDs.push('m00' + i);
                             }
@@ -93,7 +96,7 @@
                             $mdDialog.hide();
                         };
                         $scope.setPreset = function (preset) {
-                            $http(createRequest('post', urlBase + '/presetset/' + preset))
+                            $http(createRequest('post', urlBase() + '/presetset/' + preset))
                                 .then(requestSuccess, requestError);
                         };
                     },
@@ -137,7 +140,7 @@
                         };
                         $scope.gotoPreset = function (preset) {
                             vm.lastPreset = preset;
-                            $http(createRequest('post', urlBase + '/presetgoto/' + preset))
+                            $http(createRequest('post', urlBase() + '/presetgoto/' + preset))
                                 .then(requestSuccess, requestError);
                         };
                     },
@@ -193,12 +196,12 @@
         };
 
         vm.stopVDS = function () {
-            $http(createRequest('post', urlBase + '/stop'))
+            $http(createRequest('post', urlBase() + '/stop'))
                 .then(requestSuccess, requestError);
         };
 
         vm.vdsCommand = function (endpoint, args) {
-            $http(createRequest('post', urlBase + '/' + endpoint + '/' + args))
+            $http(createRequest('post', urlBase() + '/' + endpoint + '/' + args))
                 .then(requestSuccess, requestError);
         };
 

--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
     "angular-cookies": "~1.5",
     "angular-resource": "~1.5",
     "angular-mocks": "~1.5",
+    "angular-messages": "~1.5",
     "angular-ui-utils": "~0.1",
     "angular-ui-router": "~0.3",
     "cryptojs": "*",

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
 <script src="bower_components/moment/moment.js"></script>
 <script src="bower_components/sockjs/sockjs.js"></script>
 <script src="bower_components/angular/angular.js"></script>
+<script src="bower_components/angular-messages/angular-messages.js"></script>
 <script src="bower_components/angular-aria/angular-aria.js"></script>
 <script src="bower_components/angular-animate/angular-animate.js"></script>
 <script src="bower_components/hammerjs/hammer.js"></script>

--- a/update.sh
+++ b/update.sh
@@ -1,6 +1,6 @@
 echo "## Updating mkatgui code from git ..."
 git remote update -p
-git merge --ff-only master
+git merge --ff-only origin/master
 
 echo "## Updating bower and gulp ..."
 sudo -H npm update -g bower gulp


### PR DESCRIPTION
This PR contains a bunch of changes:

* There is now a 'development mode' which allows you to specify the url of katportal that you would like to connect to, this replaces the constant we had to keep changing in the control-service.js. (NOTE: the development mode input is only visible when hosting the gui locally on port 8000)
* Some basic checks has been added to the login form see screenshot:

<img width="799" alt="screen shot 2016-09-27 at 1 40 59 pm" src="https://cloud.githubusercontent.com/assets/8371143/18872313/170235a8-84ba-11e6-8399-86bdbae9202f.png">

* Bug fix - when trying to log in as lead operator when there is a lead operator, but then cancelling out of the dialog box, now correctly logs you in as read only. Also changed the wording on the dialog buttons when taking lead operator from someone to be clearer.
* Bug fix - reworked downloading csv data from sensor graph, you can now download LARGE sets of sensor samples (millions of samples), previously it would fail if there were too many samples.

* Numerous improvements to sensor graph rendering performance.
* Correctly remove the context path when removing a sensor path from sensor graph