### PR TITLE
Remove unnessary "dist" folder in Jenkins artefact path

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ node('docker') {
 
         stage 'Trigger downstream publish'
             build job: 'publish-local', parameters: [
-                string(name: 'artifact_source', value: "${currentBuild.absoluteUrl}/artifact/dist/*zip*/dist.zip"),
+                string(name: 'artifact_source', value: "${currentBuild.absoluteUrl}/artifact/*zip*/archive.zip"),
                 string(name: 'source_branch', value: "${env.BRANCH_NAME}")]
     }
 }


### PR DESCRIPTION
The dist folder is not there, so it cannot be downloaded with the old path.  The new path works at the top level.

JIRA:  CB-1531, CB-1446