### PR TITLE
User/fjoubert/cb 1859/change sb pb order vars

### DIFF
--- a/app/activity/activity.js
+++ b/app/activity/activity.js
@@ -177,6 +177,8 @@
             ObsSchedService.getScheduledScheduleBlocks().then(function(scheduleData) {
                 vm.addSbsToTimeline(scheduleData);
             });
+            // TODO update activity timeline with program blocks?
+            // ObsSchedService.getProgramBlocksObservationSchedule();
         });
 
         //This needs to run on the next digest because the timeline is not rendered yet

--- a/app/alarms/alarms.html
+++ b/app/alarms/alarms.html
@@ -20,7 +20,7 @@
                 <md-checkbox class="md-primary" ng-model="vm.showClearedAlarms" style="font-size: 13px; margin: 0">Show Cleared Alarms
                 </md-checkbox>
                 <md-menu style="padding: 0">
-                    <md-button class="md-icon-button inline-action-button" style="margin: 0 4px" ng-click="$mdOpenMenu()">
+                    <md-button class="md-icon-button inline-action-button" style="margin: 0 4px" ng-click="$mdMenu.open($event)">
                         <md-icon class="fa" md-font-icon="fa-ellipsis-v"></md-icon>
                     </md-button>
                     <md-menu-content width="4" style="padding-left: 16px; padding-right: 16px;">

--- a/app/cam-components/cam-components.html
+++ b/app/cam-components/cam-components.html
@@ -97,7 +97,7 @@
                                style="margin: 0">
                     </md-switch>
                     <md-menu style="padding: 0" ng-if="$root.expertOrLO">
-                        <md-button class="md-icon-button" ng-click="$mdOpenMenu(); $event.stopPropagation()"
+                        <md-button class="md-icon-button" ng-click="$mdMenu.open($event); $event.stopPropagation()"
                             style="height: 32px; width: 32px; margin: 0">
                             <md-icon class="fa" md-font-icon="fa-ellipsis-v"></md-icon>
                         </md-button>

--- a/app/scheduler/observations/observations-detail.html
+++ b/app/scheduler/observations/observations-detail.html
@@ -36,10 +36,10 @@
                         </md-menu-item>
                     </md-menu-content>
                 </md-menu>
-                <span style="margin-top: -14px" class="fa fa-power-off subarray-action-icon hover-opacity" md-ink-ripple
+                <span class="fa fa-power-off subarray-action-icon hover-opacity" md-ink-ripple
                     ng-show="$root.expertOrLO && vm.subarray.state === 'inactive'" title="Activate Subarray"
                     ng-click="parent.vm.activateSubarray()"></span>
-                <span style="margin-top: -14px" class="fa fa-recycle subarray-action-icon hover-opacity" md-ink-ripple
+                <span class="fa fa-recycle subarray-action-icon hover-opacity" md-ink-ripple
                     ng-show="parent.vm.iAmAtLeastCA()" title="Free Subarray" ng-click="parent.vm.freeSubarray()"></span>
             </md-toolbar>
             <div layout="column" flex ng-include="'app/scheduler/templates/pb-scheduled-list.html'"></div>

--- a/app/scheduler/observations/observations-detail.html
+++ b/app/scheduler/observations/observations-detail.html
@@ -3,10 +3,10 @@
         <div flex style="min-height: 150px;" layout="column">
             <md-toolbar md-theme="{{vm.subarray.state === 'inactive'? 'grey' : vm.subarray.state === 'active'? 'green' : vm.subarray.state === 'error'? 'amber' : 'deep-purple'}}"
                 ng-class="{'md-hue-2': vm.subarray.state !== 'inactive'}" class="md-whiteframe-z2" layout="row"
-                layout-align="center center" title="{{vm.subarray.description}}" style="max-height: 86px; min-height: 86px; position: relative">
+                layout-align="center center" title="{{vm.subarray.description}}" style="position: relative">
                 <div ng-include="'app/scheduler/templates/subarray-config-container.html'"></div>
-                <md-menu style="margin: -16px 0 0 0; padding: 0;">
-                    <md-button class="subarray-config-menu-button" title="Change Subarray" ng-click="$mdOpenMenu()" style="color: currentColor !important; font-size: 30px; position: relative">
+                <md-menu style="margin: 0; padding: 0;">
+                    <md-button class="subarray-config-menu-button" title="Change Subarray" ng-click="$mdMenu.open($event)" style="color: currentColor !important; font-size: 30px; position: relative">
                         <span class="fa fa-chevron-down subarray-select-chevron" style="top: 12px"></span>
                         <span style="margin-left: 12px;">
                                     SUBARRAY {{vm.subarray.id}} -
@@ -25,8 +25,8 @@
 
                 <span flex></span>
 
-                <md-menu style="margin: -16px 0 0 0; padding: 0px; position: relative">
-                    <span md-ink-ripple style="margin: 0; padding: 0px" ng-click="$mdOpenMenu()" class="opaque-hover">
+                <md-menu style="margin: 0; padding: 0; position: relative">
+                    <span md-ink-ripple style="margin: 0; padding: 0px" ng-click="$mdMenu.open($event)" class="opaque-hover">
                         <span class="fa fa-chevron-down subarray-select-chevron" style="top: 7px"></span>
                         <span style="margin-left: 16px">MODE: <b>{{vm.subarray.mode}}</b></span> </span>
                     </span>
@@ -65,7 +65,6 @@
                         <span>Type</span>
                         <span>End Time</span>
                     </div>
-                    <!-- <div style="min-width: 8px" ng-show="vm.subarray && $root.elementHasScrollbar('#scheduleCompleteDataRepeat')"></div> -->
                 </div>
             </md-toolbar>
 
@@ -92,7 +91,7 @@
                         </div>
 
                         <md-menu>
-                            <span class="icon-button fa fa-ellipsis-v" md-ink-ripple style="padding: 6px" ng-click="$mdOpenMenu(); $event.stopPropagation()"></span>
+                            <span class="icon-button fa fa-ellipsis-v" md-ink-ripple style="padding: 6px" ng-click="$mdMenu.open($event); $event.stopPropagation()"></span>
                             <md-menu-content>
                                 <md-menu-item>
                                     <md-button ng-click="parent.vm.viewSBTasklog(item, 'progress')" title="View Progress output in a New Tab">View Progress</md-button>

--- a/app/scheduler/observations/observations-detail.html
+++ b/app/scheduler/observations/observations-detail.html
@@ -2,7 +2,7 @@
     <div flex layout="column">
         <div flex style="min-height: 150px;" layout="column">
             <md-toolbar md-theme="{{vm.subarray.state === 'inactive'? 'grey' : vm.subarray.state === 'active'? 'green' : vm.subarray.state === 'error'? 'amber' : 'deep-purple'}}"
-                ng-class="{'md-hue-2': vm.subarray.state !== 'inactive'}" class="md-whiteframe-z1" layout="row"
+                ng-class="{'md-hue-2': vm.subarray.state !== 'inactive'}" class="md-whiteframe-z2" layout="row"
                 layout-align="center center" title="{{vm.subarray.description}}" style="max-height: 86px; min-height: 86px; position: relative">
                 <div ng-include="'app/scheduler/templates/subarray-config-container.html'"></div>
                 <md-menu style="margin: -16px 0 0 0; padding: 0;">

--- a/app/scheduler/observations/observations-detail.html
+++ b/app/scheduler/observations/observations-detail.html
@@ -1,12 +1,11 @@
 <div flex layout="row" style="min-width: 1000px; min-height: 650px; padding: 0 8px 8px 8px" ng-controller="SubArrayObservationsDetail as vm">
-
     <div flex layout="column">
         <div flex style="min-height: 150px;" layout="column">
             <md-toolbar md-theme="{{vm.subarray.state === 'inactive'? 'grey' : vm.subarray.state === 'active'? 'green' : vm.subarray.state === 'error'? 'amber' : 'deep-purple'}}"
                 ng-class="{'md-hue-2': vm.subarray.state !== 'inactive'}" class="md-whiteframe-z1" layout="row"
-                layout-align="center center" title="{{vm.subarray.description}}" style="max-height: 76px; min-height: 76px; position: relative">
+                layout-align="center center" title="{{vm.subarray.description}}" style="max-height: 86px; min-height: 86px; position: relative">
                 <div ng-include="'app/scheduler/templates/subarray-config-container.html'"></div>
-                <md-menu style="margin: 0; padding: 0;">
+                <md-menu style="margin: -16px 0 0 0; padding: 0;">
                     <md-button class="subarray-config-menu-button" title="Change Subarray" ng-click="$mdOpenMenu()" style="color: currentColor !important; font-size: 30px; position: relative">
                         <span class="fa fa-chevron-down subarray-select-chevron" style="top: 12px"></span>
                         <span style="margin-left: 12px;">
@@ -26,10 +25,10 @@
 
                 <span flex></span>
 
-                <md-menu style="margin-top: 16px; position: relative">
-                    <span md-ink-ripple style="padding: 6px" ng-click="$mdOpenMenu()" class="opaque-hover">
+                <md-menu style="margin: -16px 0 0 0; padding: 0px; position: relative">
+                    <span md-ink-ripple style="margin: 0; padding: 0px" ng-click="$mdOpenMenu()" class="opaque-hover">
                         <span class="fa fa-chevron-down subarray-select-chevron" style="top: 7px"></span>
-                        <span style="margin-left: 6px">MODE: <b>{{vm.subarray.mode}}</b></span>                        </span>
+                        <span style="margin-left: 6px">MODE: <b>{{vm.subarray.mode}}</b></span> </span>
                     </span>
                     <md-menu-content>
                         <md-menu-item ng-repeat="type in vm.modeTypes">
@@ -42,10 +41,8 @@
                     ng-click="parent.vm.activateSubarray()"></span>
                 <span style="margin-top: -14px" class="fa fa-recycle subarray-action-icon hover-opacity" md-ink-ripple
                     ng-show="parent.vm.iAmAtLeastCA()" title="Free Subarray" ng-click="parent.vm.freeSubarray()"></span>
-
-                <div ng-include="'app/scheduler/templates/sb-scheduled-list-header.html'"></div>
             </md-toolbar>
-            <div layout="column" flex ng-include="'app/scheduler/templates/sb-scheduled-list.html'"></div>
+            <div layout="column" flex ng-include="'app/scheduler/templates/pb-scheduled-list.html'"></div>
         </div>
 
         <div style="margin-top: 8px" layout="column">

--- a/app/scheduler/observations/observations-detail.html
+++ b/app/scheduler/observations/observations-detail.html
@@ -28,7 +28,7 @@
                 <md-menu style="margin: -16px 0 0 0; padding: 0px; position: relative">
                     <span md-ink-ripple style="margin: 0; padding: 0px" ng-click="$mdOpenMenu()" class="opaque-hover">
                         <span class="fa fa-chevron-down subarray-select-chevron" style="top: 7px"></span>
-                        <span style="margin-left: 6px">MODE: <b>{{vm.subarray.mode}}</b></span> </span>
+                        <span style="margin-left: 16px">MODE: <b>{{vm.subarray.mode}}</b></span> </span>
                     </span>
                     <md-menu-content>
                         <md-menu-item ng-repeat="type in vm.modeTypes">

--- a/app/scheduler/observations/observations-detail.js
+++ b/app/scheduler/observations/observations-detail.js
@@ -14,6 +14,7 @@
         vm.scheduleCompletedData = ObsSchedService.scheduleCompletedData;
         vm.observationSchedule = ObsSchedService.observationSchedule;
         vm.subarray = $scope.$parent.vm.subarray;
+        $scope.subarray = vm.subarray;
 
         vm.showSchedSBDetails = $localStorage.showSchedSBDetails;
         vm.showCompletedSBs = $localStorage.showCompletedSBs;
@@ -44,10 +45,12 @@
         if (!$scope.$parent.vm.subarray) {
             $scope.$parent.vm.waitForSubarrayToExist().then(function (subarrayId) {
                 vm.subarray = _.findWhere(ObsSchedService.subarrays, {id: subarrayId});
+                $scope.subarray = vm.subarray;
                 vm.getCompletedScheduleBlocks();
             });
         } else {
             vm.subarray = $scope.$parent.vm.subarray;
+            $scope.subarray = vm.subarray;
             vm.getCompletedScheduleBlocks();
         }
 

--- a/app/scheduler/observations/observations-detail.js
+++ b/app/scheduler/observations/observations-detail.js
@@ -12,6 +12,7 @@
         vm.modeTypes = ['queue', 'manual'];
         vm.scheduleData = ObsSchedService.scheduleData;
         vm.scheduleCompletedData = ObsSchedService.scheduleCompletedData;
+        vm.observationSchedule = ObsSchedService.observationSchedule;
         vm.subarray = $scope.$parent.vm.subarray;
 
         vm.showSchedSBDetails = $localStorage.showSchedSBDetails;

--- a/app/scheduler/observations/observations-overview.html
+++ b/app/scheduler/observations/observations-overview.html
@@ -1,4 +1,4 @@
-<div flex layout="column" style="min-width: 1015px; min-height: 600px; margin: 0 8px 8px 8px" ng-controller="SubArrayExecutorOverview as vm">
+<div flex layout="column" style="min-width: 1015px; min-height: 1000px; margin: 0 8px 8px 8px" ng-controller="SubArrayExecutorOverview as vm">
     <div flex ng-repeat="subarray in vm.subarrays | orderBy:'id'" class="subarray-container md-whiteframe-z2"
         layout="row" flex style="min-height: 120px" md-theme="{{subarray.state === 'inactive'? 'grey' : subarray.state === 'active'? 'green' : subarray.state === 'error'? 'amber' : 'deep-purple'}}">
         <div layout="column" flex>

--- a/app/scheduler/observations/observations-overview.html
+++ b/app/scheduler/observations/observations-overview.html
@@ -4,66 +4,15 @@
         <div layout="column" flex>
 
             <md-toolbar ng-class="{'md-hue-2': subarray.state !== 'inactive'}" class="md-whiteframe-z1" layout="row"
-                layout-align="center center" title="{{subarray.description}}" style="max-height: 48px; min-height: 48px; position: relative"
+                layout-align="start center" title="{{subarray.description}}" style="max-height: 48px; min-height: 48px; position: relative"
                 ng-click="parent.vm.stateGo('scheduler.observations.detail', subarray.id)">
                 <span style="margin-left: 8px;">SUBARRAY {{subarray.id}} -
                             <span><b>{{subarray.state}}</b></span>
                 <span ng-if="subarray.maintenance">{{"- in maintenance"}}</span>
                 </span>
-                <span flex></span>
-                <div layout="row" layout-align="center center" style="position: absolute; padding: 0; top: 0; left: 0; right: 0; font-size: 12px">
-                    <span title="Control Authority" style="margin-right: 8px;"><i>CA: </i><b>{{subarray.delegated_ca}}</b></span>
-                    <span title="Selected Band" style="margin-right: 8px;"><i>Band: </i><b>{{subarray.band ? subarray.band : 'None'}}</b></span>
-                    <span title="Selected Product" style="margin-right: 8px;"><i>Product: </i><b>{{subarray.product ? subarray.product : 'None'}}</b></span>
-                    <span ng-show="subarray.state === 'active' || subarray.config_label" title="Config Label"><i>Config Label: </i><b>{{subarray.config_label ? subarray.config_label : 'None'}}</b></span>
-                </div>
-                <div class="unselectable list-subheader-title subheader-text avoid-clicks" layout="row" layout-align="start end"
-                    style="cursor: default">
-                    <span style="width: 128px; padding-left: 12px" class="subheader-text">ID</span>
-                    <span flex>Description</span>
-                    <span style="width: 80px">State</span>
-                    <div style="width: 158px; font-size: 10px" layout="column">
-                        <span>Obs Readiness</span>
-                        <span>Verification State</span>
-                    </div>
-                    <div style="width: 94px; font-size: 10px" layout="column">
-                        <span>Type</span>
-                        <span>Desired Time</span>
-                    </div>
-                    <!-- <div style="min-width: 8px" ng-show="subarray && $root.elementHasScrollbar('#scheduleDataRepeat' + subarray.id, false)"></div> -->
-                </div>
-
+                <div ng-include="'app/scheduler/templates/subarray-config-container.html'"></div>
             </md-toolbar>
-            <div flex id="{{'scheduleDataRepeat' + subarray.id}}" ng-class="{'maintenance-bg': subarray.maintenance}"
-                style="overflow: auto">
-                <div style="padding: 0 4px" ng-repeat="item in vm.scheduleData | filter:{sub_nr:subarray.id} track by item.id"
-                    class="schedule-draft-item" layout="column">
-                    <div flex layout="row" layout-align="start center">
-                        <md-progress-linear ng-if="item.state === 'ACTIVE'" class="md-primary progress-bar-fill" md-mode="{{item.expected_duration_seconds? 'determinate' : 'indeterminate'}}"
-                            value="{{item.progress}}" style="position: absolute; left: 0; right: 0;">
-                        </md-progress-linear>
-                        <md-progress-linear md-theme="grey" ng-if="item.verification_state === 'VERIFYING'" class="md-primary progress-bar-fill"
-                            md-mode="indeterminate" style="position: absolute; left: 0; right: 0;">
-                        </md-progress-linear>
-                        <span style="min-width: 14px"></span>
-                        <div layout="column" layout-align="start" style="width: 120px" class="text-overflow-ellipsis">
-                            <span ng-class="{'manual-color': item.type === 'MANUAL', 'maintenance-color': item.type === 'MAINTENANCE', 'observation-color': item.type === 'OBSERVATION'}"
-                                style="font-size: 14px; font-weight: bold" ng-click="$root.showSBDetails(item, $event);$event.stopPropagation();">{{item.id_code}}</span>
-                            <i style="width: 110px">{{item.owner}}</i>
-                        </div>
-                        <span flex style="overflow: hidden; text-overflow: ellipsis; margin-right: 4px" title="{{item.description}}">{{item.description}}</span>
-                        <span style="width: 75px">{{item.state}}</span>
-                        <div layout="column" layout-align="center" class="sb-obs-readiness-div" style="margin: 0 4px">
-                            <span style="width: 150px" ng-class="{'green-color': item.obs_readiness === 'READY_TO_EXECUTE', 'red-color': item.obs_readiness !== 'READY_TO_EXECUTE'}">{{item.obs_readiness}}</span>
-                            <span style="width: 150px">{{item.verification_state}}</span>
-                        </div>
-                        <div layout="column" layout-align="center" class="sb-time-and-type-div" style="margin: 0 4px">
-                            <span ng-class="{'manual-color': item.type === 'MANUAL', 'maintenance-color': item.type === 'MAINTENANCE', 'observation-color': item.type === 'OBSERVATION'}">{{item.type}}</span>
-                            <span>{{item.desired_start_time}}</span>
-                        </div>
-                    </div>
-                </div>
-            </div>
+            <div layout="column" style="overflow: auto" ng-include="'app/scheduler/templates/pb-scheduled-list.html'"></div>
         </div>
     </div>
 </div>

--- a/app/scheduler/observations/observations-overview.js
+++ b/app/scheduler/observations/observations-overview.js
@@ -10,6 +10,7 @@
         vm.scheduleData = ObsSchedService.scheduleData;
         $scope.$parent.vm.subarray = null;
         $scope.parent = $scope.$parent;
+        vm.observationSchedule = ObsSchedService.observationSchedule;
 
         vm.navigateToSchedulerDetails = function (subarray_id) {
             $state.go('scheduler.observations.detail', {subarray_id: subarray_id});

--- a/app/scheduler/program-blocks/program-block-view.html
+++ b/app/scheduler/program-blocks/program-block-view.html
@@ -7,7 +7,12 @@
     </md-toolbar>
     <md-virtual-repeat-container flex class="md-whiteframe-z1" md-theme="{{$root.themePrimaryButtons}}">
         <div md-virtual-repeat="pb in vm.programBlocks | regexSearch:vm.pbsOrderByFields:vm.q | orderBy:vm.pbsOrderBy.value:vm.pbsOrderBy.reverse" class="pb-view-item" layout="row" ng-init="pb.showSBList = false"
-            layout-align="start center" style="cursor: pointer" ng-click="pb.showSBList = !pb.showSBList">
+            layout-align="start center" ng-click="pb.showSBList = !pb.showSBList">
+            <div class="sb-ordering-container" title="Director Priority | PB Order | PB Sequence" layout="column">
+                <div ng-click="parent.vm.directorPriorityDialog(pb, $event)">{{pb.director_priority}}</div>
+                <div ng-click="parent.vm.pbSequenceDialog(pb, $event)">{{pb.pb_sequence}}</div>
+                <div ng-click="parent.vm.pbOrderDialog(pb, $event)">{{pb.pb_order}}</div>
+            </div>
             <div layout="column" layout-align="center start" class="pb-id-container" ng-click="$root.showSBDetails(pb, $event, 'Program Block: ' + pb.pb_id)">
                 <span class="pb-id">{{pb.pb_id}}</span>
                 <span>{{pb.owner}}</span>
@@ -28,6 +33,16 @@
                     <md-menu-item ng-repeat="sub_nr in $root.systemConfig.subarrayNrs">
                         <md-button ng-click="parent.vm.setupSubarrayFromPB(sub_nr, pb.id, $event)" title="Setup subarray {{sub_nr}} using this observation specification and schedule block list">
                             Setup Subarray {{sub_nr}} with this PB</md-button>
+                    </md-menu-item>
+                    <md-menu-divider></md-menu-divider>
+                    <md-menu-item>
+                        <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.directorPriorityDialog(pb, $event)" title="Update Lead Operator Priority">Update Director Priority...</md-button>
+                    </md-menu-item>
+                    <md-menu-item>
+                        <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.pbOrderDialog(pb, $event)" title="Update SB Order">Update PB Order...</md-button>
+                    </md-menu-item>
+                    <md-menu-item>
+                        <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.pbSequenceDialog(pb, $event)" title="Update SB Sequence">Update PB Sequence...</md-button>
                     </md-menu-item>
                     <md-menu-divider></md-menu-divider>
                     <md-menu-item>

--- a/app/scheduler/program-blocks/program-block-view.html
+++ b/app/scheduler/program-blocks/program-block-view.html
@@ -28,7 +28,7 @@
                 <span>{{pb.desired_start_time}}</span>
             </div>
             <md-menu>
-                <span class="icon-button fa fa-ellipsis-v" md-ink-ripple ng-click="$mdOpenMenu(); $event.stopPropagation()"></span>
+                <span class="icon-button fa fa-ellipsis-v" md-ink-ripple ng-click="$mdMenu.open($event); $event.stopPropagation()"></span>
                 <md-menu-content style="max-height: 475px">
                     <md-menu-item ng-repeat="sub_nr in $root.systemConfig.subarrayNrs">
                         <md-button ng-click="parent.vm.setupSubarrayFromPB(sub_nr, pb.id, $event)" title="Setup subarray {{sub_nr}} using this observation specification and schedule block list">
@@ -52,6 +52,15 @@
                     <md-menu-item>
                         <md-button ng-click="parent.vm.clonePB(pb, true)" title="Clone Program Block as well as it's Schedule Blocks">
                             Clone PB and it's SB's</md-button>
+                    </md-menu-item>
+                    <md-menu-divider></md-menu-divider>
+                    <md-menu-item>
+                        <md-button ng-disabled="!pb.obs_constraints" ng-click="$root.showSBDetails(pb.obs_constraints, $event, pb.pb_id + ' Observation Constraints')" title="View Observation Constraints">
+                            View Obs Constraints</md-button>
+                    </md-menu-item>
+                    <md-menu-item>
+                        <md-button ng-disabled="!pb.obs_spec" ng-click="$root.showSBDetails(pb.obs_spec, $event, pb.pb_id + ' Observation Spec')" title="View Observation Specification">
+                            View Obs Spec</md-button>
                     </md-menu-item>
                 </md-menu-content>
             </md-menu>

--- a/app/scheduler/program-blocks/program-block-view.html
+++ b/app/scheduler/program-blocks/program-block-view.html
@@ -36,13 +36,13 @@
                     </md-menu-item>
                     <md-menu-divider></md-menu-divider>
                     <md-menu-item>
-                        <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.directorPriorityDialog(pb, $event)" title="Update Lead Operator Priority">Update Director Priority...</md-button>
+                        <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.directorPriorityDialog(pb, $event)" title="Update Director Priority">Update Director Priority...</md-button>
                     </md-menu-item>
                     <md-menu-item>
-                        <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.pbOrderDialog(pb, $event)" title="Update SB Order">Update PB Order...</md-button>
+                        <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.pbSequenceDialog(pb, $event)" title="Update PB Sequence">Update PB Sequence...</md-button>
                     </md-menu-item>
                     <md-menu-item>
-                        <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.pbSequenceDialog(pb, $event)" title="Update SB Sequence">Update PB Sequence...</md-button>
+                        <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.pbOrderDialog(pb, $event)" title="Update PB Order">Update PB Order...</md-button>
                     </md-menu-item>
                     <md-menu-divider></md-menu-divider>
                     <md-menu-item>

--- a/app/scheduler/schedule-block-drafts/schedule-block-drafts.html
+++ b/app/scheduler/schedule-block-drafts/schedule-block-drafts.html
@@ -68,7 +68,7 @@
                         md-ink-ripple title="Delete Draft Schedule Block" ng-click="vm.removeDraft(item); $event.stopPropagation()"
                         ng-if="!item.editing"></span>
                     <md-menu>
-                        <span class="icon-button fa fa-ellipsis-v" md-ink-ripple style="padding: 6px" ng-click="$mdOpenMenu(); $event.stopPropagation()"></span>
+                        <span class="icon-button fa fa-ellipsis-v" md-ink-ripple style="padding: 6px" ng-click="$mdMenu.open($event); $event.stopPropagation()"></span>
                         <md-menu-content>
                             <md-menu-item>
                                 <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="item.editing = true">Edit</md-button>

--- a/app/scheduler/schedule-block-drafts/schedule-block-drafts.html
+++ b/app/scheduler/schedule-block-drafts/schedule-block-drafts.html
@@ -32,7 +32,6 @@
                     <span class="fa" ng-class="{'fa-caret-up': vm.draftsOrderBy.value === 'desired_start_time' && !vm.draftsOrderBy.reverse, 'fa-caret-down': vm.draftsOrderBy.value === 'desired_start_time' && vm.draftsOrderBy.reverse}"
                         style="margin-right: 4px;"></span>
                     </span>
-                    <!-- <div style="min-width: 8p§x" ng-show="$root.elementHasScrollbar('#scheduleDraftDataRepeat', true)"></div> -->
                 </div>
             </md-toolbar>
             <md-virtual-repeat-container ng-click="showDatePicker = false" flex id="scheduleDraftDataRepeat">

--- a/app/scheduler/scheduler-home.js
+++ b/app/scheduler/scheduler-home.js
@@ -114,6 +114,7 @@
         ObsSchedService.getProgramBlocks();
         ObsSchedService.getScheduleBlocks();
         ObsSchedService.getScheduledScheduleBlocks();
+        ObsSchedService.getProgramBlocksObservationSchedule();
 
         vm.checkCASubarrays = function() {
             vm.subarray = _.findWhere(ObsSchedService.subarrays, {

--- a/app/scheduler/scheduler-home.js
+++ b/app/scheduler/scheduler-home.js
@@ -631,7 +631,7 @@
         vm.pbOrderDialog = function(pb, event) {
             var confirm = $mdDialog.prompt()
                 .title('Set PB Order for ' + pb.pb_id)
-                .textContent('')
+                .textContent('Must be an number between 0 and 100 ("none" or empty to clear)')
                 .placeholder('PB Order')
                 .ariaLabel('PB Order')
                 .initialValue(pb.pb_order)

--- a/app/scheduler/scheduler-home.js
+++ b/app/scheduler/scheduler-home.js
@@ -414,7 +414,17 @@
                         };
 
                         $scope.acceptDialogAction = function() {
-                            ObsSchedService.cloneSBIntoPB($scope.sb, $scope.selectedPB);
+                            ObsSchedService.cloneSBIntoPB($scope.sb, $scope.selectedPB).then(
+                                function(updateResult) {
+                                    if (updateResult.data.error) {
+                                        NotifyService.showPreDialog('Error cloning SB into PB', updateResult.data.error);
+                                    } else {
+                                        NotifyService.showSimpleToast('Cloned SB ' + sb.id_code + ' into PB ' + $scope.selectedPB.pb_id);
+                                    }
+                                },
+                                function(error) {
+                                    NotifyService.showPreDialog('Error cloning SB into PB', error);
+                                });
                             $mdDialog.hide();
                         };
 
@@ -443,8 +453,15 @@
 
                         $scope.acceptDialogAction = function() {
                             ObsSchedService.updateScheduleBlockWithProgramBlockID(sb, $scope.selectedPB).then(
-                                function() {
-                                    NotifyService.showSimpleToast('Moved SB ' + sb.id_code + ' into PB ' + $scope.selectedPB.pb_id);
+                                function(updateResult) {
+                                    if (updateResult.data.error) {
+                                        NotifyService.showPreDialog('Error moving SB into PB', updateResult.data.error);
+                                    } else {
+                                        NotifyService.showSimpleToast('Moved SB ' + sb.id_code + ' into PB ' + $scope.selectedPB.pb_id);
+                                    }
+                                },
+                                function(error) {
+                                    NotifyService.showPreDialog('Error moving SB into PB', error);
                                 });
                             $mdDialog.hide();
                         };
@@ -456,6 +473,235 @@
                     templateUrl: 'app/scheduler/templates/program-block-select.html',
                     targetEvent: event
                 });
+        };
+
+        vm.leadOperatorPriorityDialog = function(sb, event) {
+            var confirm = $mdDialog.prompt()
+                .title('Set Lead Operator Priority for ' + sb.id_code)
+                .textContent('Must be an number between 0 and 100 ("none" or empty to clear)')
+                .placeholder('Lead Operator Priority')
+                .ariaLabel('Lead Operator Priority')
+                .initialValue(sb.lead_operator_priority)
+                .targetEvent(event)
+                .theme($rootScope.themePrimaryButtons)
+                .ok('Save')
+                .cancel('Cancel');
+
+            $mdDialog.show(confirm).then(function(result) {
+                var parsedResult = parseInt(result);
+                if (result !== '' && result !== 'none' && (isNaN(parsedResult) || parsedResult < 0 || parsedResult > 100)) {
+                    vm.leadOperatorPriorityDialog(sb);
+                } else if (result === 'none' || result === '' || parsedResult > -1 || parsedResult < 101) {
+                    if (result === '') {
+                        result = 'none';
+                    }
+                    ObsSchedService.updateSBOrderingValues(
+                        sb.id_code, result, sb.sb_order, sb.sb_sequence).then(
+                        function(updateResult) {
+                            if (updateResult.data.error) {
+                                NotifyService.showPreDialog('Error updating Lead Operator Priority', updateResult.data.error);
+                            } else {
+                                NotifyService.showSimpleToast('Updated SB ' + sb.id_code + ' lead_operator_priority to ' + updateResult.data.result.lead_operator_priority);
+                            }
+                        },
+                        function(error) {
+                            NotifyService.showPreDialog('Error updating Lead Operator Priority', error);
+                        });
+                }
+            }, function() {
+                NotifyService.showSimpleToast('Cancelled Lead Operator Priority edit for ' + sb.id_code);
+            });
+        };
+
+        vm.sbOrderDialog = function(sb, event) {
+            var confirm = $mdDialog.prompt()
+                .title('Set SB Order for ' + sb.id_code)
+                .textContent('Must be an number between 0 and 100 ("none" or empty to clear)')
+                .placeholder('SB Order')
+                .ariaLabel('SB Order')
+                .initialValue(sb.sb_order)
+                .targetEvent(event)
+                .theme($rootScope.themePrimaryButtons)
+                .ok('Save')
+                .cancel('Cancel');
+
+            $mdDialog.show(confirm).then(function(result) {
+                var parsedResult = parseInt(result);
+                if (result !== '' && result !== 'none' && (isNaN(parsedResult) || parsedResult < 0 || parsedResult > 100)) {
+                    vm.sbOrderDialog(sb);
+                } else if (result === 'none' || result === '' || parsedResult > -1 || parsedResult < 101) {
+                    if (result === '') {
+                        result = 'none';
+                    }
+                    ObsSchedService.updateSBOrderingValues(
+                        sb.id_code, sb.lead_operator_priority, result, sb.sb_sequence).then(
+                        function(updateResult) {
+                            if (updateResult.data.error) {
+                                NotifyService.showPreDialog('Error updating SB Order', updateResult.data.error);
+                            } else {
+                                NotifyService.showSimpleToast('Updated SB ' + sb.id_code + ' sb_order to ' + updateResult.data.result.sb_order);
+                            }
+                        },
+                        function(error) {
+                            NotifyService.showPreDialog('Error updating SB Order', error);
+                        });
+                }
+            }, function() {
+                NotifyService.showSimpleToast('Cancelled SB Order edit for ' + sb.id_code);
+            });
+        };
+
+        vm.sbSequenceDialog = function(sb, event) {
+            var confirm = $mdDialog.prompt()
+                .title('Set SB Sequence for ' + sb.id_code)
+                .textContent('Must be an number between 0 and 100 ("none" or empty to clear)')
+                .placeholder('SB Sequence')
+                .ariaLabel('SB Sequence')
+                .initialValue(sb.sb_sequence)
+                .targetEvent(event)
+                .theme($rootScope.themePrimaryButtons)
+                .ok('Save')
+                .cancel('Cancel');
+
+            $mdDialog.show(confirm).then(function(result) {
+                var parsedResult = parseInt(result);
+                if (result !== '' && result !== 'none' && (isNaN(parsedResult) || parsedResult < 0 || parsedResult > 100)) {
+                    vm.sbSequenceDialog(sb);
+                } else if (result === 'none' || result === '' || parsedResult > -1 || parsedResult < 101) {
+                    if (result === '') {
+                        result = 'none';
+                    }
+                    ObsSchedService.updateSBOrderingValues(
+                        sb.id_code, sb.lead_operator_priority, sb.sb_order, result).then(
+                        function(updateResult) {
+                            if (updateResult.data.error) {
+                                NotifyService.showPreDialog('Error updating SB Sequence', updateResult.data.error);
+                            } else {
+                                NotifyService.showSimpleToast('Updated SB ' + sb.id_code + ' sb_sequence to ' + updateResult.data.result.sb_sequence);
+                            }
+
+                        },
+                        function(error) {
+                            NotifyService.showPreDialog('Error updating SB Sequence', error);
+                        });
+                }
+            }, function() {
+                NotifyService.showSimpleToast('Cancelled SB Order edit for ' + sb.id_code);
+            });
+        };
+
+        vm.directorPriorityDialog = function(pb, event) {
+            var confirm = $mdDialog.prompt()
+                .title('Set Director Priority for ' + pb.pb_id)
+                .textContent('Must be an number between 0 and 100 ("none" or empty to clear)')
+                .placeholder('Director Priority')
+                .ariaLabel('Director Priority')
+                .initialValue(pb.director_priority)
+                .targetEvent(event)
+                .theme($rootScope.themePrimaryButtons)
+                .ok('Save')
+                .cancel('Cancel');
+
+            $mdDialog.show(confirm).then(function(result) {
+                var parsedResult = parseInt(result);
+                if (result !== '' && result !== 'none' && (isNaN(parsedResult) || parsedResult < 0 || parsedResult > 100)) {
+                    vm.directorPriorityDialog(pb);
+                } else if (result === 'none' || result === '' || parsedResult > -1 || parsedResult < 101) {
+                    if (result === '') {
+                        result = 'none';
+                    }
+                    ObsSchedService.updatePBOrderingValues(
+                        pb.pb_id, result, pb.pb_order, pb.pb_sequence).then(
+                        function(updateResult) {
+                            if (updateResult.data.error) {
+                                NotifyService.showPreDialog('Error updating Director Priority', updateResult.data.error);
+                            } else {
+                                NotifyService.showSimpleToast('Updated SB ' + pb.pb_id + ' director_priority to ' + updateResult.data.result.director_priority);
+                            }
+                        },
+                        function(error) {
+                            NotifyService.showPreDialog('Error updating Director Priority', error);
+                        });
+                }
+            }, function() {
+                NotifyService.showSimpleToast('Cancelled Director Priority edit for ' + pb.pb_id);
+            });
+        };
+
+        vm.pbOrderDialog = function(pb, event) {
+            var confirm = $mdDialog.prompt()
+                .title('Set PB Order for ' + pb.pb_id)
+                .textContent('')
+                .placeholder('PB Order')
+                .ariaLabel('PB Order')
+                .initialValue(pb.pb_order)
+                .targetEvent(event)
+                .theme($rootScope.themePrimaryButtons)
+                .ok('Save')
+                .cancel('Cancel');
+
+            $mdDialog.show(confirm).then(function(result) {
+                var parsedResult = parseInt(result);
+                if (result !== '' && result !== 'none' && (isNaN(parsedResult) || parsedResult < 0 || parsedResult > 100)) {
+                    vm.pbOrderDialog(pb);
+                } else if (result === 'none' || result === '' || parsedResult > -1 || parsedResult < 101) {
+                    if (result === '') {
+                        result = 'none';
+                    }
+                    ObsSchedService.updatePBOrderingValues(
+                        pb.pb_id, pb.director_priority, result, pb.pb_sequence).then(
+                        function(updateResult) {
+                            if (updateResult.data.error) {
+                                NotifyService.showPreDialog('Error updating PB Order', updateResult.data.error);
+                            } else {
+                                NotifyService.showSimpleToast('Updated PB ' + pb.pb_id + ' pb_order to ' + updateResult.data.result.pb_order);
+                            }
+                        },
+                        function(error) {
+                            NotifyService.showPreDialog('Error updating PB Order', error);
+                        });
+                }
+            }, function() {
+                NotifyService.showSimpleToast('Cancelled PB Order edit for ' + pb.pb_id);
+            });
+        };
+
+        vm.pbSequenceDialog = function(pb, event) {
+            var confirm = $mdDialog.prompt()
+                .title('Set PB Sequence for ' + pb.pb_id)
+                .textContent('Must be an number between 0 and 100 ("none" or empty to clear)')
+                .placeholder('PB Sequence')
+                .ariaLabel('PB Sequence')
+                .initialValue(pb.pb_sequence)
+                .targetEvent(event)
+                .theme($rootScope.themePrimaryButtons)
+                .ok('Save')
+                .cancel('Cancel');
+
+            $mdDialog.show(confirm).then(function(result) {
+                var parsedResult = parseInt(result);
+                if (result !== '' && result !== 'none' && (isNaN(parsedResult) || parsedResult < 0 || parsedResult > 100)) {
+                    vm.pbSequenceDialog(pb);
+                } else if (result === 'none' || result === '' || parsedResult > -1 || parsedResult < 101) {
+                    if (result === '') {
+                        result = 'none';
+                    }
+                    ObsSchedService.updatePBOrderingValues(
+                        pb.pb_id, pb.director_priority, pb.pb_order, result).then(
+                        function(updateResult) {
+                            if (updateResult.data.error) {
+                                NotifyService.showPreDialog('Error updating PB Sequence', updateResult.data.error);
+                            } else {
+                                NotifyService.showSimpleToast('Updated PB ' + pb.pb_id + ' pb_sequence to ' + updateResult.data.result.pb_sequence);
+                            }
+                        },
+                        function(error) {
+                            NotifyService.showPreDialog('Error updating PB Sequence', error);
+                        });
+                }
+            }, function() {
+                NotifyService.showSimpleToast('Cancelled PB Order edit for ' + pb.pb_id);
+            });
         };
 
         vm.cloneAndAssignSB = function(item) {

--- a/app/scheduler/scheduler-home.js
+++ b/app/scheduler/scheduler-home.js
@@ -751,6 +751,12 @@
                 });
         };
 
+        vm.hasScheduleBlocks = function(item) {
+            return function(item) {
+                return angular.isDefined(item.schedule_blocks) && item.schedule_blocks.length > 0;
+            };
+        };
+
         $scope.$on('$destroy', function() {
             MonitorService.unsubscribe('sched', '*');
             vm.unbindStateChangeStart();

--- a/app/scheduler/scheduler-home.js
+++ b/app/scheduler/scheduler-home.js
@@ -113,7 +113,6 @@
         MonitorService.subscribe('sched');
         ObsSchedService.getProgramBlocks();
         ObsSchedService.getScheduleBlocks();
-        ObsSchedService.getScheduledScheduleBlocks();
         ObsSchedService.getProgramBlocksObservationSchedule();
 
         vm.checkCASubarrays = function() {

--- a/app/scheduler/scheduler-home.js
+++ b/app/scheduler/scheduler-home.js
@@ -476,12 +476,18 @@
         };
 
         vm.leadOperatorPriorityDialog = function(sb, event) {
+            var initValue = sb.lead_operator_priority;
+            if (initValue !== null && initValue > -1) {
+                initValue = initValue.toString();
+            } else {
+                initValue = '';
+            }
             var confirm = $mdDialog.prompt()
                 .title('Set Lead Operator Priority for ' + sb.id_code)
                 .textContent('Must be an number between 0 and 100 ("none" or empty to clear)')
                 .placeholder('Lead Operator Priority')
                 .ariaLabel('Lead Operator Priority')
-                .initialValue(sb.lead_operator_priority)
+                .initialValue(initValue)
                 .targetEvent(event)
                 .theme($rootScope.themePrimaryButtons)
                 .ok('Save')
@@ -514,12 +520,18 @@
         };
 
         vm.sbOrderDialog = function(sb, event) {
+            var initValue = sb.sb_order;
+            if (initValue !== null && initValue > -1) {
+                initValue = initValue.toString();
+            } else {
+                initValue = '';
+            }
             var confirm = $mdDialog.prompt()
                 .title('Set SB Order for ' + sb.id_code)
                 .textContent('Must be an number between 0 and 100 ("none" or empty to clear)')
                 .placeholder('SB Order')
                 .ariaLabel('SB Order')
-                .initialValue(sb.sb_order)
+                .initialValue(initValue)
                 .targetEvent(event)
                 .theme($rootScope.themePrimaryButtons)
                 .ok('Save')
@@ -552,12 +564,18 @@
         };
 
         vm.sbSequenceDialog = function(sb, event) {
+            var initValue = sb.sb_sequence;
+            if (initValue !== null && initValue > -1) {
+                initValue = initValue.toString();
+            } else {
+                initValue = '';
+            }
             var confirm = $mdDialog.prompt()
                 .title('Set SB Sequence for ' + sb.id_code)
                 .textContent('Must be an number between 0 and 100 ("none" or empty to clear)')
                 .placeholder('SB Sequence')
                 .ariaLabel('SB Sequence')
-                .initialValue(sb.sb_sequence)
+                .initialValue(initValue)
                 .targetEvent(event)
                 .theme($rootScope.themePrimaryButtons)
                 .ok('Save')
@@ -591,12 +609,18 @@
         };
 
         vm.directorPriorityDialog = function(pb, event) {
+            var initValue = pb.director_priority;
+            if (initValue !== null && initValue > -1) {
+                initValue = initValue.toString();
+            } else {
+                initValue = '';
+            }
             var confirm = $mdDialog.prompt()
                 .title('Set Director Priority for ' + pb.pb_id)
                 .textContent('Must be an number between 0 and 100 ("none" or empty to clear)')
                 .placeholder('Director Priority')
                 .ariaLabel('Director Priority')
-                .initialValue(pb.director_priority)
+                .initialValue(initValue)
                 .targetEvent(event)
                 .theme($rootScope.themePrimaryButtons)
                 .ok('Save')
@@ -629,12 +653,18 @@
         };
 
         vm.pbOrderDialog = function(pb, event) {
+            var initValue = pb.pb_order;
+            if (initValue !== null && initValue > -1) {
+                initValue = initValue.toString();
+            } else {
+                initValue = '';
+            }
             var confirm = $mdDialog.prompt()
                 .title('Set PB Order for ' + pb.pb_id)
                 .textContent('Must be an number between 0 and 100 ("none" or empty to clear)')
                 .placeholder('PB Order')
                 .ariaLabel('PB Order')
-                .initialValue(pb.pb_order)
+                .initialValue(initValue)
                 .targetEvent(event)
                 .theme($rootScope.themePrimaryButtons)
                 .ok('Save')
@@ -667,12 +697,18 @@
         };
 
         vm.pbSequenceDialog = function(pb, event) {
+            var initValue = pb.pb_sequence;
+            if (initValue !== null && initValue > -1) {
+                initValue = initValue.toString();
+            } else {
+                initValue = '';
+            }
             var confirm = $mdDialog.prompt()
                 .title('Set PB Sequence for ' + pb.pb_id)
                 .textContent('Must be an number between 0 and 100 ("none" or empty to clear)')
                 .placeholder('PB Sequence')
                 .ariaLabel('PB Sequence')
-                .initialValue(pb.pb_sequence)
+                .initialValue(initValue)
                 .targetEvent(event)
                 .theme($rootScope.themePrimaryButtons)
                 .ok('Save')

--- a/app/scheduler/scheduler.less
+++ b/app/scheduler/scheduler.less
@@ -101,7 +101,7 @@
     position: relative;
     font-size: 12px;
     white-space: nowrap;
-    margin-top: 4px;
+    margin-top: 8px;
 
     .pb-schedule-item-header {
         height: 84px;
@@ -112,9 +112,9 @@
     position: absolute;
     top: 2px;
     left: 32px;
-    right: 0;
+    right: 32px;
     font-size: 18px;
-    // text-align: center;
+    text-align: center;
 }
 
 .schedule-draft-item {

--- a/app/scheduler/scheduler.less
+++ b/app/scheduler/scheduler.less
@@ -96,6 +96,27 @@
     }
 }
 
+.pb-schedule-item {
+    z-index: 0;
+    position: relative;
+    font-size: 12px;
+    white-space: nowrap;
+    margin-top: 4px;
+
+    .pb-schedule-item-header {
+        height: 84px;
+        position: relative;
+    }
+}
+.pb-schedule-item-header-title {
+    position: absolute;
+    top: 2px;
+    left: 32px;
+    right: 0;
+    font-size: 18px;
+    // text-align: center;
+}
+
 .schedule-draft-item {
     z-index: 0;
     position: relative;
@@ -133,6 +154,24 @@
         }
         .pb-id {
             font-size: 14px;
+            font-weight: bold;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            max-width: 160px;
+            width: 100%;
+        }
+    }
+
+    .pb-id-container-big {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        margin: 0 8px;
+
+        .owner {
+            font-style: italic;
+        }
+        .pb-id {
+            font-size: 16px;
             font-weight: bold;
             overflow: hidden;
             text-overflow: ellipsis;

--- a/app/scheduler/scheduler.less
+++ b/app/scheduler/scheduler.less
@@ -118,7 +118,7 @@
     white-space: nowrap;
     direction: ltr;
     border: 1px solid rgba(158, 158, 158, 0.3);
-    padding: 0 8px;
+    padding: 0;
     &:hover {
         background-color: rgba(158, 158, 158, 0.1);
     }
@@ -127,7 +127,7 @@
         max-width: 125px;
         overflow: hidden;
         text-overflow: ellipsis;
-        margin-right: 8px;
+        margin: 0 8px;
         .owner {
             font-style: italic;
         }
@@ -631,4 +631,29 @@
     overflow: auto;
     white-space: pre-wrap;
     border-radius: 0;
+}
+
+.sb-ordering-container {
+    min-width: 14px;
+    max-width: 14px;
+    font-size: 9px;
+
+    div {
+        opacity: 0.6;
+        overflow: hidden;
+        min-height: 10px;
+        text-align: center;
+
+        &:hover {
+            opacity: inherit;
+        }
+    }
+}
+
+.pb-disabled-select {
+    opacity: 0.6;
+    cursor: not-allowed;
+    &:hover {
+        background-color: inherit !important;
+    }
 }

--- a/app/scheduler/subarray-resources/subarray-resources.html
+++ b/app/scheduler/subarray-resources/subarray-resources.html
@@ -10,7 +10,7 @@
                         layout="row" layout-align="center center" title="{{vm.subarray.description}}" style="max-height: 56px; min-height: 56px; position: relative">
                         <div ng-include="'app/scheduler/templates/subarray-config-container.html'"></div>
                         <md-menu style="margin: 0; padding: 0;">
-                            <md-button class="subarray-config-menu-button" title="Change Subarray" ng-click="$mdOpenMenu(); $event.stopPropagation()"
+                            <md-button class="subarray-config-menu-button" title="Change Subarray" ng-click="$mdMenu.open($event); $event.stopPropagation()"
                                 style="font-size: 30px">
                                 <span class="fa fa-chevron-down subarray-select-chevron" style="top: 12px"></span>
                                 <span style="margin-left: 14px">
@@ -37,7 +37,7 @@
 
                         <md-menu ng-show="$root.expertOrLO" md-theme="{{themePrimary}}">
                             <md-button style="padding: 0; font-size: 24px" class="md-icon-button inline-action-button hover-opacity"
-                                ng-click="vm.initLastKnownConfig(); $mdOpenMenu()">
+                                ng-click="vm.initLastKnownConfig(); $mdMenu.open($event)">
                                 <span class="fa fa-ellipsis-v"></span>
                             </md-button>
                             <md-menu-content style="min-height: 427px">

--- a/app/scheduler/subarrays-draft-assignment/subarrays-draft-assignment.html
+++ b/app/scheduler/subarrays-draft-assignment/subarrays-draft-assignment.html
@@ -126,13 +126,11 @@
                 <md-icon class="fa" md-font-icon="fa-chevron-left" style="width: auto; height: auto"></md-icon>
             </md-button>
         </div>
-        <div layout="column" style="padding-right: 4px">
-            <md-toolbar ng-class="{'md-hue-2': vm.subarray.state !== 'inactive'}" style="margin-top: 8px" class="md-whiteframe-z1 md-toolbar-tools-medium"
-                layout="row" layout-align="center center" title="{{vm.subarray.description}}">
-                <div ng-include="'app/scheduler/templates/sb-scheduled-list-header.html'"></div>
-                <span md-ink-ripple flex title="Click to view scheduling details" style="margin-top: -5px; margin-left: 8px" ng-click="parent.vm.stateGo('scheduler.observations.detail')">Observations</span>
+        <div layout="column" style="padding-right: 4px" class="md-whiteframe-z1">
+            <md-toolbar ng-class="{'md-hue-2': vm.subarray.state !== 'inactive'}" style="margin-top: 8px" class="md-whiteframe-z2 md-toolbar-tools-medium">
+                <span md-ink-ripple flex title="Click to view scheduling details" ng-click="parent.vm.stateGo('scheduler.observations.detail')">Observations</span>
             </md-toolbar>
-            <div layout="column" style="min-height: 200px" ng-include="'app/scheduler/templates/sb-scheduled-list.html'"></div>
+            <div layout="column" style="min-height: 350px; max-height: 350px; overflow: auto" ng-include="'app/scheduler/templates/pb-scheduled-list.html'"></div>
         </div>
     </div>
 

--- a/app/scheduler/subarrays-draft-assignment/subarrays-draft-assignment.html
+++ b/app/scheduler/subarrays-draft-assignment/subarrays-draft-assignment.html
@@ -36,10 +36,9 @@
                                 <span class="fa" ng-class="{'fa-caret-up': vm.draftsOrderBy.value === 'desired_start_time' && !vm.draftsOrderBy.reverse, 'fa-caret-down': vm.draftsOrderBy.value === 'desired_start_time' && vm.draftsOrderBy.reverse}" style="margin-right: 4px;"></span>
                             </span>
                         </div>
-                        <!-- <div style="min-width: 8px" ng-show="vm.subarray && $root.elementHasScrollbar('#scheduleDraftDataRepeat', true)"></div> -->
                     </div>
                     <md-menu>
-                        <md-button class="subarray-config-menu-button" title="Change Subarray" ng-click="$mdOpenMenu(); $event.stopPropagation()"
+                        <md-button class="subarray-config-menu-button" title="Change Subarray" ng-click="$mdMenu.open($event); $event.stopPropagation()"
                             style="font-size: inherit">
                             <span class="fa fa-chevron-down subarray-select-chevron" style="top: 6px"></span>
                             <span style="margin-left: 14px;">
@@ -85,7 +84,7 @@
                         <span class="icon-button fa fa-chevron-right" md-ink-ripple ng-disabled="!parent.vm.iAmAtLeastCA()" title="Unassign Schedule Blocks"
                             ng-click="parent.vm.iAmAtLeastCA() && vm.freeScheduleBlock(item)"></span>
                         <md-menu>
-                            <span class="icon-button fa fa-ellipsis-v" md-ink-ripple style="padding: 6px" ng-click="$mdOpenMenu(); $event.stopPropagation()"></span>
+                            <span class="icon-button fa fa-ellipsis-v" md-ink-ripple style="padding: 6px" ng-click="$mdMenu.open($event); $event.stopPropagation()"></span>
                             <md-menu-content>
                                 <md-menu-item>
                                     <md-button ng-disabled="!(item.type === 'OBSERVATION' && parent.vm.iAmAtLeastCA())" ng-click="vm.verifyDraft(item)">Verify Draft</md-button>

--- a/app/scheduler/subarrays-draft-assignment/subarrays-draft-assignment.html
+++ b/app/scheduler/subarrays-draft-assignment/subarrays-draft-assignment.html
@@ -130,7 +130,7 @@
             <md-toolbar ng-class="{'md-hue-2': vm.subarray.state !== 'inactive'}" style="margin-top: 8px" class="md-whiteframe-z1 md-toolbar-tools-medium"
                 layout="row" layout-align="center center" title="{{vm.subarray.description}}">
                 <div ng-include="'app/scheduler/templates/sb-scheduled-list-header.html'"></div>
-                <span md-ink-ripple flex title="Click to view scheduling details" style="margin-top: -5px;" ng-click="parent.vm.stateGo('scheduler.observations.detail')">Observations</span>
+                <span md-ink-ripple flex title="Click to view scheduling details" style="margin-top: -5px; margin-left: 8px" ng-click="parent.vm.stateGo('scheduler.observations.detail')">Observations</span>
             </md-toolbar>
             <div layout="column" style="min-height: 200px" ng-include="'app/scheduler/templates/sb-scheduled-list.html'"></div>
         </div>

--- a/app/scheduler/subarrays-draft-assignment/subarrays-draft-assignment.js
+++ b/app/scheduler/subarrays-draft-assignment/subarrays-draft-assignment.js
@@ -16,9 +16,11 @@
         if (!$scope.$parent.vm.subarray) {
             $scope.$parent.vm.waitForSubarrayToExist().then(function (subarrayId) {
                 vm.subarray = _.findWhere(ObsSchedService.subarrays, {id: subarrayId});
+                $scope.subarray = vm.subarray;
             });
         } else {
             vm.subarray = $scope.$parent.vm.subarray;
+            $scope.subarray = vm.subarray;
         }
         $scope.parent = $scope.$parent;
 

--- a/app/scheduler/subarrays-draft-assignment/subarrays-draft-assignment.js
+++ b/app/scheduler/subarrays-draft-assignment/subarrays-draft-assignment.js
@@ -11,6 +11,7 @@
         vm.showDeselectTooltip = false;
         vm.scheduleDraftData = ObsSchedService.scheduleDraftData;
         vm.scheduleData = ObsSchedService.scheduleData;
+        vm.observationSchedule = ObsSchedService.observationSchedule;
 
         if (!$scope.$parent.vm.subarray) {
             $scope.$parent.vm.waitForSubarrayToExist().then(function (subarrayId) {

--- a/app/scheduler/templates/pb-scheduled-list.html
+++ b/app/scheduler/templates/pb-scheduled-list.html
@@ -1,7 +1,7 @@
-<div flex md-theme="{{themePrimaryButtons}}" class="md-whiteframe-z2" ng-class="{'maintenance-bg':vm.subarray.maintenance}" style="overflow: auto">
-    <div ng-repeat="pb in vm.observationSchedule | filter:parent.vm.hasScheduleBlocks(pb) | filter:{sub_nr: vm.subarray.id} track by $index" class="pb-schedule-item" layout="column">
+<div flex md-theme="{{themePrimaryButtons}}" class="md-whiteframe-z2" ng-class="{'maintenance-bg':subarray.maintenance}" style="overflow: auto">
+    <div ng-repeat="pb in vm.observationSchedule | filter:parent.vm.hasScheduleBlocks(pb) | filter:{sub_nr: subarray.id} track by $index" class="pb-schedule-item" layout="column">
         <md-toolbar flex class="pb-schedule-item-header md-hue-3 pb-view-item md-whiteframe-z1" md-theme="{{themePrimary}}" title="{{pb.description}}">
-            <div style="position: absolute; left: 4px; top: 4px" class="sb-ordering-container" title="Director Priority | PB Order | PB Sequence" layout="column">
+            <div ng-show="pb.id > -1" style="position: absolute; left: 4px; top: 4px" class="sb-ordering-container" title="Director Priority | PB Order | PB Sequence" layout="column">
                 <div ng-click="parent.vm.directorPriorityDialog(pb, $event)">{{pb.director_priority}}</div>
                 <div ng-click="parent.vm.pbSequenceDialog(pb, $event)">{{pb.pb_sequence}}</div>
                 <div ng-click="parent.vm.pbOrderDialog(pb, $event)">{{pb.pb_order}}</div>
@@ -23,12 +23,6 @@
             <md-menu style="position: absolute; top: 4px; right: 4px">
                 <span class="icon-button fa fa-ellipsis-v" md-ink-ripple ng-click="$mdOpenMenu(); $event.stopPropagation()"></span>
                 <md-menu-content style="max-height: 475px">
-                    <!-- <md-menu-item>
-                    <md-button ng-click="parent.vm.setupSubarrayFromPB(parent.vm.subarray_id, pb.id, $event)" title="Setup subarray {{parent.vm.subarray_id}} using this observation specification and schedule block list">
-                        Setup Subarray {{parent.vm.subarray_id}} with this PB
-                    </md-button>
-                </md-menu-item> -->
-                    <!-- <md-menu-divider></md-menu-divider> -->
                     <md-menu-item>
                         <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.directorPriorityDialog(pb, $event)"
                             title="Update Lead Operator Priority">Update Director Priority...</md-button>

--- a/app/scheduler/templates/pb-scheduled-list.html
+++ b/app/scheduler/templates/pb-scheduled-list.html
@@ -11,7 +11,7 @@
                 {{pb.description}}
             </span>
 
-            <div ng-show="pb.id > -1" layout="column" layout-align="center" style="position: absolute; top: 2px; right: 120px; font-size: 9px">
+            <div ng-show="pb.id > -1" layout="column" layout-align="center" style="position: absolute; top: 2px; right: 40px; font-size: 9px; max-width: 162px; min-width: 162px">
                 <span>Desired LST Start Time: {{pb.desired_lst_start_time}}</span>
                 <span>Desired Start Time: {{pb.desired_start_time}}</span>
             </div>

--- a/app/scheduler/templates/pb-scheduled-list.html
+++ b/app/scheduler/templates/pb-scheduled-list.html
@@ -1,0 +1,71 @@
+<div flex md-theme="{{themePrimaryButtons}}" class="md-whiteframe-z2" ng-class="{'maintenance-bg':vm.subarray.maintenance}" style="overflow: auto">
+    <div ng-repeat="pb in vm.observationSchedule track by $index" class="pb-schedule-item" layout="column">
+        <md-toolbar flex class="pb-schedule-item-header md-hue-3 pb-view-item" md-theme="{{themePrimary}}" title="{{pb.description}}">
+            <div style="position: absolute; left: 4px; top: 4px" class="sb-ordering-container" title="Director Priority | PB Order | PB Sequence" layout="column">
+                <div ng-click="parent.vm.directorPriorityDialog(pb, $event)">{{pb.director_priority}}</div>
+                <div ng-click="parent.vm.pbSequenceDialog(pb, $event)">{{pb.pb_sequence}}</div>
+                <div ng-click="parent.vm.pbOrderDialog(pb, $event)">{{pb.pb_order}}</div>
+            </div>
+            <span style="position: absolute; top: 26px; left: 16px; right: 16px; height: 20px; min-width: 140px; overflow: hidden; text-overflow: ellipsis"
+                layout="row" layout-align="start center" title="{{pb.description}}">
+                {{pb.description}}
+            </span>
+            <!-- <span class="pb-obs-spec-list-item" style="font-size: 10px; min-width: 200px; max-width:200px" title="{{pb.obs_spec}}">{{pb.obs_spec}}</span> -->
+            <!-- <div layout="column" layout-align="center" class="sb-time-and-type-div" style="margin-left: 4px; min-width: 148px">
+                <span>{{pb.desired_lst_start_time}}</span>
+                <span>{{pb.desired_start_time}}</span>
+            </div> -->
+
+            <div class="pb-schedule-item-header-title" ng-click="$root.showSBDetails(pb, $event, 'Program Block: ' + pb.pb_id)">Program Block - <b>{{pb.pb_id}}</b></div>
+            <md-menu style="position: absolute; top: 4px; right: 4px">
+                <span class="icon-button fa fa-ellipsis-v" md-ink-ripple ng-click="$mdOpenMenu(); $event.stopPropagation()"></span>
+                <md-menu-content style="max-height: 475px">
+                    <!-- <md-menu-item>
+                    <md-button ng-click="parent.vm.setupSubarrayFromPB(parent.vm.subarray_id, pb.id, $event)" title="Setup subarray {{parent.vm.subarray_id}} using this observation specification and schedule block list">
+                        Setup Subarray {{parent.vm.subarray_id}} with this PB
+                    </md-button>
+                </md-menu-item> -->
+                    <!-- <md-menu-divider></md-menu-divider> -->
+                    <md-menu-item>
+                        <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.directorPriorityDialog(pb, $event)"
+                            title="Update Lead Operator Priority">Update Director Priority...</md-button>
+                    </md-menu-item>
+                    <md-menu-item>
+                        <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.pbOrderDialog(pb, $event)" title="Update SB Order">Update PB Order...</md-button>
+                    </md-menu-item>
+                    <md-menu-item>
+                        <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.pbSequenceDialog(pb, $event)"
+                            title="Update SB Sequence">Update PB Sequence...</md-button>
+                    </md-menu-item>
+                    <md-menu-divider></md-menu-divider>
+                    <md-menu-item>
+                        <md-button ng-click="parent.vm.clonePB(pb, false)" title="Clone Program Block without it's Schedule Blocks">
+                            Clone PB only</md-button>
+                    </md-menu-item>
+                    <md-menu-item>
+                        <md-button ng-click="parent.vm.clonePB(pb, true)" title="Clone Program Block as well as it's Schedule Blocks">
+                            Clone PB and it's SB's</md-button>
+                    </md-menu-item>
+                </md-menu-content>
+            </md-menu>
+            <div ng-include="'app/scheduler/templates/sb-scheduled-list-header.html'" class="list-subheader-title"
+                style="height: 32px; border-top: 1px solid rgba(158,158,158,0.5); border-top-style: dashed; width: calc(100% - 8px);"></div>
+        </md-toolbar>
+
+        <div ng-repeat="sb in pb.schedule_blocks track by $index" style="margin: 0 16px; z-index: 0; min-width: calc(100% - 32px)"
+            ng-class="{'selected-schedule-row md-whiteframe-z3': sb === vm.selectedSchedule}" class="schedule-draft-item"
+            layout="row" layout-align="start center" ng-click='vm.setSelectedSchedule(sb)' ng-include="'app/scheduler/templates/sb-single-scheduled-line-item.html'">
+        </div>
+    </div>
+    <md-toolbar flex class="pb-schedule-item-header md-hue-3 pb-view-item" md-theme="{{themePrimary}}" title="{{pb.description}}"
+        style="margin-top: 16px">
+        <div class="pb-schedule-item-header-title">Unlinked Schedule Blocks</div>
+
+        <div ng-include="'app/scheduler/templates/sb-scheduled-list-header.html'" class="list-subheader-title"
+            style="height: 32px; border-top: 1px solid rgba(158,158,158,0.5); border-top-style: dashed; width: calc(100% - 8px);"></div>
+    </md-toolbar>
+    <div ng-repeat="sb in vm.scheduleData | filter:{pb_id: null} track by $index" style="margin: 0 16px; z-index: 0; min-width: calc(100% - 32px)"
+        ng-class="{'selected-schedule-row md-whiteframe-z3': sb === vm.selectedSchedule}" class="schedule-draft-item"
+        layout="row" layout-align="start center" ng-click='vm.setSelectedSchedule(sb)' ng-include="'app/scheduler/templates/sb-single-scheduled-line-item.html'">
+    </div>
+</div>

--- a/app/scheduler/templates/pb-scheduled-list.html
+++ b/app/scheduler/templates/pb-scheduled-list.html
@@ -1,6 +1,6 @@
 <div flex md-theme="{{themePrimaryButtons}}" class="md-whiteframe-z2" ng-class="{'maintenance-bg':vm.subarray.maintenance}" style="overflow: auto">
-    <div ng-repeat="pb in vm.observationSchedule track by $index" class="pb-schedule-item" layout="column">
-        <md-toolbar flex class="pb-schedule-item-header md-hue-3 pb-view-item" md-theme="{{themePrimary}}" title="{{pb.description}}">
+    <div ng-repeat="pb in vm.observationSchedule | filter:parent.vm.hasScheduleBlocks(pb) | filter:{sub_nr: vm.subarray.id} track by $index" class="pb-schedule-item" layout="column">
+        <md-toolbar flex class="pb-schedule-item-header md-hue-3 pb-view-item md-whiteframe-z1" md-theme="{{themePrimary}}" title="{{pb.description}}">
             <div style="position: absolute; left: 4px; top: 4px" class="sb-ordering-container" title="Director Priority | PB Order | PB Sequence" layout="column">
                 <div ng-click="parent.vm.directorPriorityDialog(pb, $event)">{{pb.director_priority}}</div>
                 <div ng-click="parent.vm.pbSequenceDialog(pb, $event)">{{pb.pb_sequence}}</div>
@@ -16,7 +16,10 @@
                 <span>{{pb.desired_start_time}}</span>
             </div> -->
 
-            <div class="pb-schedule-item-header-title" ng-click="$root.showSBDetails(pb, $event, 'Program Block: ' + pb.pb_id)">Program Block - <b>{{pb.pb_id}}</b></div>
+            <div class="pb-schedule-item-header-title" ng-click="$root.showSBDetails(pb, $event, 'Program Block: ' + pb.pb_id)">
+                <span ng-show="pb.id > -1">Program Block - <b>{{pb.pb_id}}</b></span>
+                <b ng-show="!pb.id && pb.id !== 0">{{pb.pb_id}}</b>
+            </div>
             <md-menu style="position: absolute; top: 4px; right: 4px">
                 <span class="icon-button fa fa-ellipsis-v" md-ink-ripple ng-click="$mdOpenMenu(); $event.stopPropagation()"></span>
                 <md-menu-content style="max-height: 475px">
@@ -49,23 +52,12 @@
                 </md-menu-content>
             </md-menu>
             <div ng-include="'app/scheduler/templates/sb-scheduled-list-header.html'" class="list-subheader-title"
-                style="height: 32px; border-top: 1px solid rgba(158,158,158,0.5); border-top-style: dashed; width: calc(100% - 8px);"></div>
+                style="height: 32px; border-top: 1px solid rgba(158,158,158,0.5); border-top-style: dashed; width: 100%"></div>
         </md-toolbar>
 
         <div ng-repeat="sb in pb.schedule_blocks track by $index" style="margin: 0 16px; z-index: 0; min-width: calc(100% - 32px)"
             ng-class="{'selected-schedule-row md-whiteframe-z3': sb === vm.selectedSchedule}" class="schedule-draft-item"
             layout="row" layout-align="start center" ng-click='vm.setSelectedSchedule(sb)' ng-include="'app/scheduler/templates/sb-single-scheduled-line-item.html'">
         </div>
-    </div>
-    <md-toolbar flex class="pb-schedule-item-header md-hue-3 pb-view-item" md-theme="{{themePrimary}}" title="{{pb.description}}"
-        style="margin-top: 16px">
-        <div class="pb-schedule-item-header-title">Unlinked Schedule Blocks</div>
-
-        <div ng-include="'app/scheduler/templates/sb-scheduled-list-header.html'" class="list-subheader-title"
-            style="height: 32px; border-top: 1px solid rgba(158,158,158,0.5); border-top-style: dashed; width: calc(100% - 8px);"></div>
-    </md-toolbar>
-    <div ng-repeat="sb in vm.scheduleData | filter:{pb_id: null} track by $index" style="margin: 0 16px; z-index: 0; min-width: calc(100% - 32px)"
-        ng-class="{'selected-schedule-row md-whiteframe-z3': sb === vm.selectedSchedule}" class="schedule-draft-item"
-        layout="row" layout-align="start center" ng-click='vm.setSelectedSchedule(sb)' ng-include="'app/scheduler/templates/sb-single-scheduled-line-item.html'">
     </div>
 </div>

--- a/app/scheduler/templates/pb-scheduled-list.html
+++ b/app/scheduler/templates/pb-scheduled-list.html
@@ -20,7 +20,7 @@
                 <span ng-show="pb.id > -1">Program Block - <b>{{pb.pb_id}}</b></span>
                 <b ng-show="!pb.id && pb.id !== 0">{{pb.pb_id}}</b>
             </div>
-            <md-menu style="position: absolute; top: 4px; right: 4px">
+            <md-menu ng-show="pb.id > -1" style="position: absolute; top: 4px; right: 4px">
                 <span class="icon-button fa fa-ellipsis-v" md-ink-ripple ng-click="$mdMenu.open($event); $event.stopPropagation()"></span>
                 <md-menu-content style="max-height: 475px">
                     <md-menu-item>
@@ -28,11 +28,12 @@
                             title="Update Lead Operator Priority">Update Director Priority...</md-button>
                     </md-menu-item>
                     <md-menu-item>
-                        <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.pbOrderDialog(pb, $event)" title="Update SB Order">Update PB Order...</md-button>
-                    </md-menu-item>
-                    <md-menu-item>
                         <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.pbSequenceDialog(pb, $event)"
                             title="Update SB Sequence">Update PB Sequence...</md-button>
+                    </md-menu-item>
+                    <md-menu-item >
+                        <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.pbOrderDialog(pb, $event)"
+                        title="Update PB Order">Update PB Order...</md-button>
                     </md-menu-item>
                     <md-menu-divider></md-menu-divider>
                     <md-menu-item>

--- a/app/scheduler/templates/pb-scheduled-list.html
+++ b/app/scheduler/templates/pb-scheduled-list.html
@@ -10,18 +10,18 @@
                 layout="row" layout-align="start center" title="{{pb.description}}">
                 {{pb.description}}
             </span>
-            <!-- <span class="pb-obs-spec-list-item" style="font-size: 10px; min-width: 200px; max-width:200px" title="{{pb.obs_spec}}">{{pb.obs_spec}}</span> -->
-            <!-- <div layout="column" layout-align="center" class="sb-time-and-type-div" style="margin-left: 4px; min-width: 148px">
-                <span>{{pb.desired_lst_start_time}}</span>
-                <span>{{pb.desired_start_time}}</span>
-            </div> -->
+
+            <div ng-show="pb.id > -1" layout="column" layout-align="center" style="position: absolute; top: 2px; right: 120px; font-size: 9px">
+                <span>Desired LST Start Time: {{pb.desired_lst_start_time}}</span>
+                <span>Desired Start Time: {{pb.desired_start_time}}</span>
+            </div>
 
             <div class="pb-schedule-item-header-title" ng-click="$root.showSBDetails(pb, $event, 'Program Block: ' + pb.pb_id)">
                 <span ng-show="pb.id > -1">Program Block - <b>{{pb.pb_id}}</b></span>
                 <b ng-show="!pb.id && pb.id !== 0">{{pb.pb_id}}</b>
             </div>
             <md-menu style="position: absolute; top: 4px; right: 4px">
-                <span class="icon-button fa fa-ellipsis-v" md-ink-ripple ng-click="$mdOpenMenu(); $event.stopPropagation()"></span>
+                <span class="icon-button fa fa-ellipsis-v" md-ink-ripple ng-click="$mdMenu.open($event); $event.stopPropagation()"></span>
                 <md-menu-content style="max-height: 475px">
                     <md-menu-item>
                         <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.directorPriorityDialog(pb, $event)"
@@ -42,6 +42,15 @@
                     <md-menu-item>
                         <md-button ng-click="parent.vm.clonePB(pb, true)" title="Clone Program Block as well as it's Schedule Blocks">
                             Clone PB and it's SB's</md-button>
+                    </md-menu-item>
+                    <md-menu-divider></md-menu-divider>
+                    <md-menu-item>
+                        <md-button ng-disabled="!pb.obs_constraints" ng-click="$root.showSBDetails(pb.obs_constraints, $event, pb.pb_id + ' Observation Constraints')" title="View Observation Constraints">
+                            View Obs Constraints</md-button>
+                    </md-menu-item>
+                    <md-menu-item>
+                        <md-button ng-disabled="!pb.obs_spec" ng-click="$root.showSBDetails(pb.obs_spec, $event, pb.pb_id + ' Observation Spec')" title="View Observation Specification">
+                            View Obs Spec</md-button>
                     </md-menu-item>
                 </md-menu-content>
             </md-menu>

--- a/app/scheduler/templates/pb-view-header.html
+++ b/app/scheduler/templates/pb-view-header.html
@@ -1,5 +1,7 @@
 <div class="unselectable list-subheader-title subheader-text" layout="row" layout-align="start end" ng-click="$event.stopPropagation()">
-    <div style="width: 134px; font-size: 10px">
+    <span style="line-height: 9px; font-size: 9px; margin-left: -6px; word-break: break-all; width: 16px"
+        class="subheader-text" title="Order of Program Blocks by director_priority, sb_order and sb_sequence">DP Seq Ord</span>
+    <div style="width: 134px; margin-left: 4px; font-size: 10px">
         <div class="subheader-text" ng-click="vm.setPBsOrderBy('pb_id')">
             <span>PB ID</span>
             <span class="fa" style="margin-right: 4px;"

--- a/app/scheduler/templates/program-block-select.html
+++ b/app/scheduler/templates/program-block-select.html
@@ -2,7 +2,9 @@
     <md-toolbar class="md-primary" style="position: relative; height: 48px">
         <span flex style="position: absolute; top: 8px; left: 0; right: 0; text-align: center">{{title}}</span>
         <div class="unselectable list-subheader-title subheader-text" layout="row" layout-align="start end">
-            <div style="width: 134px; font-size: 10px">
+            <span style="line-height: 9px; font-size: 9px; margin-left: -6px; word-break: break-all; width: 16px"
+                class="subheader-text" title="Order of Program Blocks by director_priority, sb_order and sb_sequence">DP Seq Ord</span>
+            <div style="width: 134px; margin-left: 4px; font-size: 10px">
                 <div class="subheader-text">PB ID</div>
                 <div>Owner</div>
             </div>
@@ -18,7 +20,13 @@
     </md-toolbar>
     <div flex layout="column" style="overflow-x: auto; overflow-y: scroll">
         <div ng-repeat="pb in programBlocks | orderBy:pb.id:true track by pb.pb_id" class="pb-view-item" layout="row" layout-align="start center"
-            ng-click="setSelectedPB(pb)" style="min-height: 44px; min-width: 800px; padding-right: 0" ng-class="{'selected-resource-item': pb.id === selectedPB.id}">
+            ng-click="sb.pb_id !== pb.id && setSelectedPB(pb)" style="min-height: 44px; min-width: 800px; padding-right: 0"
+            ng-class="{'selected-resource-item': pb.id === selectedPB.id, 'pb-disabled-select': sb.pb_id === pb.id}">
+            <div class="sb-ordering-container" title="Director Priority | PB Order | PB Sequence" layout="column">
+                <div>{{pb.director_priority}}</div>
+                <div>{{pb.pb_sequence}}</div>
+                <div>{{pb.pb_order}}</div>
+            </div>
             <div layout="column" layout-align="center start" class="pb-id-container">
                 <span class="pb-id">{{pb.pb_id}}</span>
                 <span>{{pb.owner}}</span>

--- a/app/scheduler/templates/sb-scheduled-list-header.html
+++ b/app/scheduler/templates/sb-scheduled-list-header.html
@@ -13,7 +13,7 @@
         <span>Obs Readiness</span>
         <span>Verification State</span>
     </div>
-    <div style="width: 148px; font-size: 10px" layout="column">
+    <div style="width: 158px; font-size: 10px" layout="column">
         <span>Type</span>
         <span>Desired Time</span>
     </div>

--- a/app/scheduler/templates/sb-scheduled-list-header.html
+++ b/app/scheduler/templates/sb-scheduled-list-header.html
@@ -17,5 +17,4 @@
         <span>Type</span>
         <span>Desired Time</span>
     </div>
-    <!-- <div style="min-width: 8px" ng-show="vm.subarray && $root.elementHasScrollbar('#scheduleDataRepeat', true)"></div> -->
 </div>

--- a/app/scheduler/templates/sb-scheduled-list-header.html
+++ b/app/scheduler/templates/sb-scheduled-list-header.html
@@ -1,8 +1,12 @@
 <div class="unselectable list-subheader-title subheader-text" layout="row" layout-align="start end" ng-click="$event.stopPropagation()"
     style="pointer-events: none">
-    <span style="line-height: 9px; font-size: 9px; margin-left: -6px; word-break: break-all; width: 16px"
-        class="subheader-text" title="Order of Schedule Blocks by lead_operator_priority, sb_order and sb_sequence">LO Seq Ord</span>
-    <span style="width: 130px; padding-left: 8px" class="subheader-text">ID</span>
+    <div layout="column" style="font-size: 9px; word-break: break-all; width: 16px; margin-left: 8px; line-height: 9px" class="subheader-text" title="Order of Schedule Blocks by lead_operator_priority, sb_order and sb_sequence">
+        <span>LOP</span>
+        <span>Seq</span>
+        <span>Ord</span>
+    </div>
+
+    <span style="width: 118px; padding-left: 2px" class="subheader-text">ID</span>
     <span flex>Description</span>
     <span style="width: 80px">State</span>
     <div style="width: 158px; font-size: 10px" layout="column">

--- a/app/scheduler/templates/sb-scheduled-list-header.html
+++ b/app/scheduler/templates/sb-scheduled-list-header.html
@@ -1,6 +1,8 @@
 <div class="unselectable list-subheader-title subheader-text" layout="row" layout-align="start end" ng-click="$event.stopPropagation()"
     style="pointer-events: none">
-    <span style="width: 130px; padding-left: 12px" class="subheader-text">ID</span>
+    <span style="line-height: 9px; font-size: 9px; margin-left: -6px; word-break: break-all; width: 16px"
+        class="subheader-text" title="Order of Schedule Blocks by lead_operator_priority, sb_order and sb_sequence">LO Seq Ord</span>
+    <span style="width: 130px; padding-left: 8px" class="subheader-text">ID</span>
     <span flex>Description</span>
     <span style="width: 80px">State</span>
     <div style="width: 158px; font-size: 10px" layout="column">

--- a/app/scheduler/templates/sb-scheduled-list.html
+++ b/app/scheduler/templates/sb-scheduled-list.html
@@ -36,7 +36,7 @@
             style="min-width: 26px; max-width: 26px"
             ng-click="item.state === 'ACTIVE'? parent.vm.stopExecuteSchedule(item) : parent.vm.executeSchedule(item); $event.stopPropagation()"></span>
         <md-menu md-theme="{{$root.themePrimaryButtons}}">
-            <span class="icon-button fa fa-ellipsis-v" md-ink-ripple ng-click="$mdOpenMenu(); $event.stopPropagation()"></span>
+            <span class="icon-button fa fa-ellipsis-v" md-ink-ripple ng-click="$mdMenu.open($event); $event.stopPropagation()"></span>
             <md-menu-content style="max-height: 475px">
                 <md-menu-item>
                     <md-button ng-click="parent.vm.viewSBTasklog(item, 'progress')" title="View Progress in a New Tab">View Progress</md-button>

--- a/app/scheduler/templates/sb-scheduled-list.html
+++ b/app/scheduler/templates/sb-scheduled-list.html
@@ -65,10 +65,10 @@
                     <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.leadOperatorPriorityDialog(item, $event)" title="Update Lead Operator Priority">Update Lead Operator Priority...</md-button>
                 </md-menu-item>
                 <md-menu-item>
-                    <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.sbOrderDialog(item, $event)" title="Update SB Order">Update SB Order...</md-button>
+                    <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.sbSequenceDialog(item, $event)" title="Update SB Sequence">Update SB Sequence...</md-button>
                 </md-menu-item>
                 <md-menu-item>
-                    <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.sbSequenceDialog(item, $event)" title="Update SB Sequence">Update SB Sequence...</md-button>
+                    <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.sbOrderDialog(item, $event)" title="Update SB Order">Update SB Order...</md-button>
                 </md-menu-item>
                 <md-menu-divider></md-menu-divider>
                 <md-menu-item>

--- a/app/scheduler/templates/sb-scheduled-list.html
+++ b/app/scheduler/templates/sb-scheduled-list.html
@@ -1,7 +1,7 @@
 <md-virtual-repeat-container id="scheduleDataRepeat" flex md-theme="{{themePrimaryButtons}}" class="md-whiteframe-z2"
-    ng-class="{'maintenance-bg':vm.subarray.maintenance}">
+    ng-class="{'maintenance-bg':vm.subarray.maintenance}" style="y-overflow: scroll">
     <div md-virtual-repeat="item in vm.currentScheduleData = (vm.scheduleData | filter:{sub_nr:vm.subarray.id})"
-        style="padding: 0 4px; z-index: 0" ng-class="{'selected-schedule-row md-whiteframe-z3': item === vm.selectedSchedule}" class="schedule-draft-item"
+        style="padding: 0 2px 0 0; z-index: 0" ng-class="{'selected-schedule-row md-whiteframe-z3': item === vm.selectedSchedule}" class="schedule-draft-item"
         layout="row" layout-align="start center" ng-click='vm.setSelectedSchedule(item)'>
 
         <md-progress-linear md-theme="green" ng-show="item.state === 'ACTIVE'" class="md-primary progress-bar-fill"
@@ -11,7 +11,11 @@
         <md-progress-linear md-theme="grey" ng-show="item.verification_state === 'VERIFYING'" class="md-primary progress-bar-fill"
             md-mode="indeterminate" style="position: absolute; left: 0; right: 0;">
         </md-progress-linear>
-        <span style="min-width: 14px"></span>
+        <div class="sb-ordering-container" title="Lead Operator Priority | SB Order | SB Sequence" layout="column">
+            <div ng-click="parent.vm.leadOperatorPriorityDialog(item, $event)">{{item.lead_operator_priority}}</div>
+            <div ng-click="parent.vm.sbSequenceDialog(item, $event)">{{item.sb_sequence}}</div>
+            <div ng-click="parent.vm.sbOrderDialog(item, $event)">{{item.sb_order}}</div>
+        </div>
         <div layout="column" layout-align="start" style="width: 120px" class="text-overflow-ellipsis">
             <span ng-class="{'manual-color': item.type === 'MANUAL', 'maintenance-color': item.type === 'MAINTENANCE', 'observation-color': item.type === 'OBSERVATION'}"
                 style="font-size: 14px; font-weight: bold" ng-click="$root.showSBDetails(item, $event);$event.stopPropagation();">{{item.id_code}}</span>
@@ -55,6 +59,16 @@
                 </md-menu-item>
                 <md-menu-item>
                     <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.cancelExecuteSchedule(item)" title="Cancel Schedule Block Execution">Cancel Execution</md-button>
+                </md-menu-item>
+                <md-menu-divider></md-menu-divider>
+                <md-menu-item>
+                    <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.leadOperatorPriorityDialog(item, $event)" title="Update Lead Operator Priority">Update Lead Operator Priority...</md-button>
+                </md-menu-item>
+                <md-menu-item>
+                    <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.sbOrderDialog(item, $event)" title="Update SB Order">Update SB Order...</md-button>
+                </md-menu-item>
+                <md-menu-item>
+                    <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.sbSequenceDialog(item, $event)" title="Update SB Sequence">Update SB Sequence...</md-button>
                 </md-menu-item>
                 <md-menu-divider></md-menu-divider>
                 <md-menu-item>

--- a/app/scheduler/templates/sb-single-scheduled-line-item.html
+++ b/app/scheduler/templates/sb-single-scheduled-line-item.html
@@ -1,0 +1,91 @@
+<md-progress-linear md-theme="green" ng-show="sb.state === 'ACTIVE' " class="md-primary progress-bar-fill"
+    md-mode="{{sb.expected_duration_seconds? 'determinate' : 'indeterminate'}}" value="{{sb.progress}}"
+    style="position: absolute; left: 0; right: 0">
+</md-progress-linear>
+<md-progress-linear md-theme="grey" ng-show="sb.verification_state === 'VERIFYING'" class="md-primary progress-bar-fill"
+    md-mode="indeterminate" style="position: absolute; left: 0; right: 0;">
+</md-progress-linear>
+<div class="sb-ordering-container" title="Lead Operator Priority | SB Order | SB Sequence" layout="column">
+    <div ng-click="parent.vm.leadOperatorPriorityDialog(sb, $event)">{{sb.lead_operator_priority}}</div>
+    <div ng-click="parent.vm.sbSequenceDialog(sb, $event)">{{sb.sb_sequence}}</div>
+    <div ng-click="parent.vm.sbOrderDialog(sb, $event)">{{sb.sb_order}}</div>
+</div>
+<div layout="column" layout-align="start" style="width: 120px" class="text-overflow-ellipsis">
+    <span ng-class="{'manual-color': sb.type === 'MANUAL', 'maintenance-color': sb.type === 'MAINTENANCE', 'observation-color': sb.type === 'OBSERVATION'}"
+        style="font-size: 14px; font-weight: bold" ng-click="$root.showSBDetails(sb, $event);$event.stopPropagation();">{{sb.id_code}}</span>
+    <i style="width: 110px">{{sb.owner}}</i>
+</div>
+<span flex style="overflow: hidden; text-overflow: ellipsis; margin-right: 4px" title="{{sb.description}}">{{sb.description}}</span>
+<span style="width: 75px">{{sb.state}}</span>
+<div layout="column" layout-align="center" class="sb-obs-readiness-div" style="margin: 0 4px">
+    <span style="width: 150px" ng-class="{'green-color': sb.obs_readiness === 'READY_TO_EXECUTE', 'red-color': sb.obs_readiness !== 'READY_TO_EXECUTE'}">{{sb.obs_readiness}}</span>
+    <span style="width: 150px">{{sb.verification_state}}</span>
+</div>
+<div layout="column" layout-align="center" class="sb-time-and-type-div" style="margin: 0 4px">
+    <span ng-class="{'manual-color': sb.type === 'MANUAL', 'maintenance-color': sb.type === 'MAINTENANCE', 'observation-color': sb.type === 'OBSERVATION'}">{{sb.type}}</span>
+    <span>{{sb.desired_start_time}}</span>
+</div>
+<span md-ink-ripple class="icon-button fa" title="{{sb.state !== 'ACTIVE'? 'Execute': 'Stop Execution'}}"
+    ng-class="{'fa-play green-color': sb.state !== 'ACTIVE' && sb.obs_readiness === 'READY_TO_EXECUTE', 'fa-stop red-color': sb.state === 'ACTIVE', 'opacity-0': sb.state !== 'ACTIVE' && sb.obs_readiness !== 'READY_TO_EXECUTE'}"
+    style="min-width: 26px; max-width: 26px"
+    ng-click="sb.state === 'ACTIVE'? parent.vm.stopExecuteSchedule(sb) : parent.vm.executeSchedule(sb); $event.stopPropagation()"></span>
+<md-menu md-theme="{{$root.themePrimaryButtons}}">
+    <span class="icon-button fa fa-ellipsis-v" md-ink-ripple ng-click="$mdOpenMenu(); $event.stopPropagation()"></span>
+    <md-menu-content style="max-height: 475px">
+        <md-menu-item>
+            <md-button ng-click="parent.vm.viewSBTasklog(sb, 'progress')" title="View Progress in a New Tab">View Progress</md-button>
+        </md-menu-item>
+        <md-menu-item>
+            <md-button ng-click="parent.vm.viewSBTasklog(sb, 'dryrun')" title="View Dryrun result in a New Tab">View Dryrun</md-button>
+        </md-menu-item>
+        <md-menu-divider></md-menu-divider>
+        <md-menu-item>
+            <md-button ng-disabled="sb.type !== 'OBSERVATION' || sb.pendingVerify || !parent.vm.iAmAtLeastCA()"
+                ng-click="parent.vm.verifySB(sb)">Verify Schedule</md-button>
+        </md-menu-item>
+        <md-menu-item>
+            <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.moveScheduleRowToApproved(sb)"
+                title="Move Schedule Block to Approved">Move to Approved</md-button>
+        </md-menu-item>
+        <md-menu-item>
+            <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.moveScheduleRowToFinished(sb)"
+                title="Move Schedule Block to Complete">Move To Completed</md-button>
+        </md-menu-item>
+        <md-menu-item>
+            <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.cancelExecuteSchedule(sb)" title="Cancel Schedule Block Execution">Cancel Execution</md-button>
+        </md-menu-item>
+        <md-menu-divider></md-menu-divider>
+        <md-menu-item>
+            <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.leadOperatorPriorityDialog(sb, $event)" title="Update Lead Operator Priority">Update Lead Operator Priority...</md-button>
+        </md-menu-item>
+        <md-menu-item>
+            <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.sbOrderDialog(sb, $event)" title="Update SB Order">Update SB Order...</md-button>
+        </md-menu-item>
+        <md-menu-item>
+            <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.sbSequenceDialog(sb, $event)" title="Update SB Sequence">Update SB Sequence...</md-button>
+        </md-menu-item>
+        <md-menu-divider></md-menu-divider>
+        <md-menu-item>
+            <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.cloneSB(sb)" title="Clone Schedule Block">Clone SB</md-button>
+        </md-menu-item>
+        <md-menu-item>
+            <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.cloneAndAssignSB(sb)"
+                title="{{'Clone and Assign to Subarray ' + vm.subarray.id}}">Clone and Assign SB</md-button>
+        </md-menu-item>
+        <md-menu-item>
+            <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.cloneAndScheduleSB(sb)"
+                title="{{'Clone and Schedule on Subarray ' + vm.subarray.id}}">Clone and Schedule SB</md-button>
+        </md-menu-item>
+        <md-menu-item>
+            <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.cloneSBIntoPBDialog($event, sb)" title="Clone Schedule Block into a Program Block">Clone SB Into PB...</md-button>
+        </md-menu-item>
+        <md-menu-divider></md-menu-divider>
+        <md-menu-item>
+            <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.moveSBIntoPBDialog($event, sb)" title="Move Schedule Block to a Program Block">Move SB to PB...</md-button>
+        </md-menu-item>
+        <md-menu-item>
+            <md-button ng-disabled="!parent.vm.iAmAtLeastCA() || sb.pb_id === null || sb.pb_id === undefined"
+                ng-click="parent.vm.removeSBFromAnyPB(sb)" title="Remove Schedule block from any Program Block">Remove SB From PB</md-button>
+        </md-menu-item>
+    </md-menu-content>
+</md-menu>

--- a/app/scheduler/templates/sb-single-scheduled-line-item.html
+++ b/app/scheduler/templates/sb-single-scheduled-line-item.html
@@ -30,7 +30,7 @@
     style="min-width: 26px; max-width: 26px"
     ng-click="sb.state === 'ACTIVE'? parent.vm.stopExecuteSchedule(sb) : parent.vm.executeSchedule(sb); $event.stopPropagation()"></span>
 <md-menu md-theme="{{$root.themePrimaryButtons}}">
-    <span class="icon-button fa fa-ellipsis-v" md-ink-ripple ng-click="$mdOpenMenu(); $event.stopPropagation()"></span>
+    <span class="icon-button fa fa-ellipsis-v" md-ink-ripple ng-click="$mdMenu.open($event); $event.stopPropagation()"></span>
     <md-menu-content style="max-height: 475px">
         <md-menu-item>
             <md-button ng-click="parent.vm.viewSBTasklog(sb, 'progress')" title="View Progress in a New Tab">View Progress</md-button>

--- a/app/scheduler/templates/sb-single-scheduled-line-item.html
+++ b/app/scheduler/templates/sb-single-scheduled-line-item.html
@@ -59,10 +59,10 @@
             <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.leadOperatorPriorityDialog(sb, $event)" title="Update Lead Operator Priority">Update Lead Operator Priority...</md-button>
         </md-menu-item>
         <md-menu-item>
-            <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.sbOrderDialog(sb, $event)" title="Update SB Order">Update SB Order...</md-button>
+            <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.sbSequenceDialog(sb, $event)" title="Update SB Sequence">Update SB Sequence...</md-button>
         </md-menu-item>
         <md-menu-item>
-            <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.sbSequenceDialog(sb, $event)" title="Update SB Sequence">Update SB Sequence...</md-button>
+            <md-button ng-disabled="!parent.vm.iAmAtLeastCA()" ng-click="parent.vm.sbOrderDialog(sb, $event)" title="Update SB Order">Update SB Order...</md-button>
         </md-menu-item>
         <md-menu-divider></md-menu-divider>
         <md-menu-item>

--- a/app/scheduler/templates/subarray-config-container.html
+++ b/app/scheduler/templates/subarray-config-container.html
@@ -2,7 +2,7 @@
     <span md-ink-ripple ng-click="parent.vm.showSubarrayAndDataLogs()" class="icon-button fa fa-file-text-o" title="Show Subarray and Data Proxy logs"
         style="font-size: 12px; height: 14px; padding: 2px 4px; opacity: 0.5"></span>
     <md-menu>
-        <span ng-disabled="!$root.expertOrLO" title="Control Authority" ng-click="$root.expertOrLO && $mdOpenMenu()"
+        <span ng-disabled="!$root.expertOrLO" title="Control Authority" ng-click="$root.expertOrLO && $mdMenu.open($event)"
             md-ink-ripple>
              <i>CA: </i><b>{{parent.vm.subarray.delegated_ca}}</b>
          </span>
@@ -20,7 +20,7 @@
         </md-menu-content>
     </md-menu>
     <md-menu>
-        <span ng-disabled="!$root.expertOrLO" title="Selected Band" ng-click="$root.expertOrLO && $mdOpenMenu()"
+        <span ng-disabled="!$root.expertOrLO" title="Selected Band" ng-click="$root.expertOrLO && $mdMenu.open($event)"
             md-ink-ripple>
              <i>Band: </i><b>{{vm.subarray.band ? vm.subarray.band : 'None'}}</b>
          </span>
@@ -33,7 +33,7 @@
         </md-menu-content>
     </md-menu>
     <md-menu>
-        <span ng-disabled="!$root.expertOrLO" title="Selected Product" ng-click="$root.expertOrLO && $mdOpenMenu()"
+        <span ng-disabled="!$root.expertOrLO" title="Selected Product" ng-click="$root.expertOrLO && $mdMenu.open($event)"
             md-ink-ripple>
              <i>Product: </i><b>{{vm.subarray.product ? vm.subarray.product : 'None'}}</b>
          </span>

--- a/app/sensor-list/sensor-list.less
+++ b/app/sensor-list/sensor-list.less
@@ -22,7 +22,6 @@
             background-color: rgba(158, 158, 158, 0.1);
         }
     }
-
 }
 
 .resource-sensor-name {
@@ -56,7 +55,9 @@
     display: inline-block;
     overflow: hidden;
     text-overflow: ellipsis;
+    min-height: 20px;
     max-height: 20px;
+    width: 100%;
 }
 
 .active-sensor-list-resource {

--- a/app/services/notify-service.js
+++ b/app/services/notify-service.js
@@ -178,10 +178,12 @@
                         } else {
                             $scope.title = title;
                         }
+                        if (_.isString(sb)) {
+                            sb = JSON.parse(sb);
+                        }
                         $scope.sb = sb;
                         $scope.hide = function () {
                             $mdDialog.hide();
-                            $rootScope.mdDialogSb = undefined;
                         };
                     },
                     template: "<md-dialog style='padding: 0; max-height: 95%' md-theme='{{$root.themePrimary}}' aria-label='Schedule Block Details'>" +

--- a/app/services/notify-service.js
+++ b/app/services/notify-service.js
@@ -321,6 +321,7 @@
                                 '<md-toolbar class="md-primary" layout="row" layout-align="center center"><span>{{title}}</span></md-toolbar>',
                                 '<div flex layout="column" layout-align="start" class="resource-sensor-item">',
                                     '<div layout="row"><span class="sensor-dialog-details-name">Name:</span><span>{{sensor.parentName? sensor.parentName + "_" + sensor.python_identifier : sensor.python_identifier}}</span></div>',
+                                    '<div layout="row" style="max-width: 700px"><span class="sensor-dialog-details-name">Description:</span><div>{{sensor.description}}</div></div>',
                                     '<div layout="row"><span class="sensor-dialog-details-name">Status:</span><span ng-class="sensorClass(sensor.status)">{{sensor.status}}</span></div>',
                                     '<div layout="row"><span class="sensor-dialog-details-name">Units:</span><span>{{sensor.units}}</span></div>',
                                     '<div layout="row"><span class="sensor-dialog-details-name">Type:</span><span>{{sensor.type}}</span></div>',

--- a/app/services/obs-sched-service.js
+++ b/app/services/obs-sched-service.js
@@ -1,14 +1,14 @@
-(function () {
+(function() {
 
     angular.module('katGui.services')
         .service('ObsSchedService', ObsSchedService);
 
     function ObsSchedService($rootScope, $http, ConfigService, KatGuiUtil,
-                             UserLogService, $log, $q, $mdDialog, NotifyService,
-                             $timeout, $interval, $localStorage) {
+        UserLogService, $log, $q, $mdDialog, NotifyService,
+        $timeout, $interval, $localStorage) {
 
         function urlBase() {
-            return $rootScope.portalUrl? $rootScope.portalUrl + '/katcontrol' : '';
+            return $rootScope.portalUrl ? $rootScope.portalUrl + '/katcontrol' : '';
         }
         var api = {};
         if (!$localStorage.lastKnownSubarrayConfig) {
@@ -28,16 +28,17 @@
         api.poolResourcesFree = [];
         api.configLabels = [];
         api.resourceTemplates = [];
+        api.observationSchedule = [];
 
         api.draftArrayStates = ['DRAFT', 'DEFINED', 'APPROVED'];
 
-        api.handleRequestResponse = function (request, defer) {
+        api.handleRequestResponse = function(request, defer) {
             var deferred;
             if (defer) {
                 deferred = $q.defer();
             }
             request
-                .then(function (result) {
+                .then(function(result) {
                     if (!result.data.error) {
                         var message = KatGuiUtil.sanitizeKATCPMessage(result.data.result);
                         if (result.data.result.split(' ')[1] === 'ok') {
@@ -57,7 +58,7 @@
                         }
                         NotifyService.showPreDialog('Error Processing Request', result.data.error);
                     }
-                }, function (error) {
+                }, function(error) {
                     if (deferred) {
                         deferred.resolve(false);
                     }
@@ -68,11 +69,15 @@
             }
         };
 
-        api.markResourceFaulty = function (resource, faulty) {
+        api.markResourceFaulty = function(resource, faulty) {
             api.handleRequestResponse($http(createRequest('post', urlBase() + '/resource/' + resource + '/faulty/' + faulty)));
             var tags = [];
-            tags.push(_.find(UserLogService.tags, function (item) {return item.name === 'status'; }));
-            var tagResource = _.find(UserLogService.tags, function (item) {return item.name === resource; });
+            tags.push(_.find(UserLogService.tags, function(item) {
+                return item.name === 'status';
+            }));
+            var tagResource = _.find(UserLogService.tags, function(item) {
+                return item.name === resource;
+            });
             if (tagResource) {
                 tags.push(tagResource);
             }
@@ -81,7 +86,7 @@
                 var newlog = {
                     start_time: $rootScope.utcDateTime,
                     end_time: '',
-                    tags:tags,
+                    tags: tags,
                     user_id: $rootScope.currentUser.id,
                     content: content
                 };
@@ -89,11 +94,15 @@
             }
         };
 
-        api.markResourceInMaintenance = function (resource, maintenance) {
+        api.markResourceInMaintenance = function(resource, maintenance) {
             api.handleRequestResponse($http(createRequest('post', urlBase() + '/resource/' + resource + '/maintenance/' + maintenance)));
             var tags = [];
-            tags.push(_.find(UserLogService.tags, function (item) {return item.name === 'maintenance'; }));
-            var tagResource = _.find(UserLogService.tags, function (item) {return item.name === resource; });
+            tags.push(_.find(UserLogService.tags, function(item) {
+                return item.name === 'maintenance';
+            }));
+            var tagResource = _.find(UserLogService.tags, function(item) {
+                return item.name === resource;
+            });
             if (tagResource) {
                 tags.push(tagResource);
             }
@@ -111,59 +120,59 @@
             }
         };
 
-        api.restartMaintenanceDevice = function (sub_nr, resource, device) {
+        api.restartMaintenanceDevice = function(sub_nr, resource, device) {
             api.handleRequestResponse($http(createRequest('post', urlBase() + '/subarray/' + sub_nr + '/resource/' + resource + '/device/' + device + '/restart')));
         };
 
-        api.listResourceMaintenanceDevices = function (resource) {
-            return $http(createRequest('get',  urlBase() + '/resource/' + resource + '/maintenance-device-list'));
+        api.listResourceMaintenanceDevices = function(resource) {
+            return $http(createRequest('get', urlBase() + '/resource/' + resource + '/maintenance-device-list'));
         };
 
-        api.deleteScheduleDraft = function (id) {
-            $http(createRequest('post', urlBase() + '/sb/' + id + '/delete')).then(function (result) {
+        api.deleteScheduleDraft = function(id) {
+            $http(createRequest('post', urlBase() + '/sb/' + id + '/delete')).then(function(result) {
                 if (result.data.error) {
                     NotifyService.showSimpleDialog('Error deleting Schedule Block', result.data.error);
                 } else {
                     NotifyService.showSimpleToast(result.data.result);
                 }
-            }, function (error) {
+            }, function(error) {
                 NotifyService.showHttpErrorDialog('Error sending request', error.data.message);
             });
         };
 
-        api.scheduleDraft = function (sub_nr, id) {
+        api.scheduleDraft = function(sub_nr, id) {
             api.handleRequestResponse($http(createRequest('post', urlBase() + '/sb/' + sub_nr + '/' + id + '/schedule')));
         };
 
-        api.scheduleToApproved = function (sub_nr, id_code) {
+        api.scheduleToApproved = function(sub_nr, id_code) {
             api.handleRequestResponse($http(createRequest('post', urlBase() + '/sb/' + sub_nr + '/' + id_code + '/to-approved')));
         };
 
-        api.scheduleToComplete = function (sub_nr, id_code) {
+        api.scheduleToComplete = function(sub_nr, id_code) {
             api.handleRequestResponse($http(createRequest('post', urlBase() + '/sb/' + sub_nr + '/' + id_code + '/complete')));
         };
 
-        api.verifyScheduleBlock = function (sub_nr, id_code) {
+        api.verifyScheduleBlock = function(sub_nr, id_code) {
             api.handleRequestResponse($http(createRequest('post', urlBase() + '/sb/' + sub_nr + '/' + id_code + '/verify')));
         };
 
-        api.executeSchedule = function (sub_nr, id_code) {
+        api.executeSchedule = function(sub_nr, id_code) {
             api.handleRequestResponse($http(createRequest('post', urlBase() + '/sb/' + sub_nr + '/' + id_code + '/execute')));
         };
 
-        api.stopSchedule = function (sub_nr, id_code) {
+        api.stopSchedule = function(sub_nr, id_code) {
             NotifyService.showImportantConfirmDialog(null, 'Stop Executing Schedule', 'Are you sure you want to stop executing ' + id_code + '?', 'Yes', 'Cancel').then(function() {
                 api.handleRequestResponse($http(createRequest('post', urlBase() + '/sb/' + sub_nr + '/' + id_code + '/stop')));
-            }, function () {
+            }, function() {
                 NotifyService.showSimpleToast('Cancelled stop executing ' + id_code);
             });
         };
 
-        api.cancelExecuteSchedule = function (sub_nr, id_code) {
+        api.cancelExecuteSchedule = function(sub_nr, id_code) {
             api.handleRequestResponse($http(createRequest('post', urlBase() + '/sb/' + sub_nr + '/' + id_code + '/cancel-execute')));
         };
 
-        api.updateScheduleBlockWithProgramBlockID = function (sb, pb) {
+        api.updateScheduleBlockWithProgramBlockID = function(sb, pb) {
             var body = {};
             if (pb && pb.pb_id) {
                 body = {
@@ -173,96 +182,98 @@
             return $http(createRequest('post', urlBase() + '/sb/' + sb.id_code + '/update-pb-id', body));
         };
 
-        api.cloneSBIntoPB = function (sb, pb) {
+        api.cloneSBIntoPB = function(sb, pb) {
             return $http(createRequest('post', urlBase() + '/sb/' + sb.id_code + '/clone', {
                 pb_id: pb.pb_id
             }));
         };
 
-        api.cloneSB = function (id_code) {
+        api.cloneSB = function(id_code) {
             return $http(createRequest('post', urlBase() + '/sb/' + id_code + '/clone'));
         };
 
-        api.clonePB = function (pb, cloneSBs) {
-            return $http(createRequest('post', urlBase() + '/pb/' + pb.pb_id + '/clone/' + (cloneSBs? '1' : '0')));
+        api.clonePB = function(pb, cloneSBs) {
+            return $http(createRequest('post', urlBase() + '/pb/' + pb.pb_id + '/clone/' + (cloneSBs ? '1' : '0')));
         };
 
-        api.cloneAndAssignSB = function (id_code, sub_nr) {
-            api.cloneSB(id_code).then(function (result) {
+        api.cloneAndAssignSB = function(id_code, sub_nr) {
+            api.cloneSB(id_code).then(function(result) {
                 if (result.data.result) {
                     api.assignScheduleBlock(sub_nr, result.data.result.id_code);
                 } else {
                     NotifyService.showPreDialog('Error Processing Request', 'Could not clone schedule block.');
                 }
-            }, function (error) {
+            }, function(error) {
                 NotifyService.showHttpErrorDialog('Error sending request', error);
             });
         };
 
-        api.cloneAndScheduleSB = function (id_code, sub_nr) {
-            api.cloneSB(id_code).then(function (result) {
+        api.cloneAndScheduleSB = function(id_code, sub_nr) {
+            api.cloneSB(id_code).then(function(result) {
                 if (result.data.result) {
                     api.scheduleDraft(sub_nr, result.data.result.id_code);
                 } else {
                     NotifyService.showPreDialog('Error Processing Request', 'Could not clone and assign schedule block.');
                 }
-            }, function (error) {
+            }, function(error) {
                 NotifyService.showHttpErrorDialog('Error sending request', error);
             });
         };
 
-        api.assignScheduleBlock = function (sub_nr, id_code) {
+        api.assignScheduleBlock = function(sub_nr, id_code) {
             return api.handleRequestResponse($http(createRequest('post', urlBase() + '/sb/' + sub_nr + '/' + id_code + '/assign')), true);
         };
 
-        api.unassignScheduleBlock = function (sub_nr, id_code) {
+        api.unassignScheduleBlock = function(sub_nr, id_code) {
             api.handleRequestResponse($http(createRequest('post', urlBase() + '/sb/' + sub_nr + '/' + id_code + '/unassign')));
         };
 
-        api.assignResourcesToSubarray = function (sub_nr, resources) {
+        api.assignResourcesToSubarray = function(sub_nr, resources) {
             return api.handleRequestResponse($http(createRequest('post', urlBase() + '/subarray/' + sub_nr + '/assign-resource/' + resources)), true);
         };
 
-        api.unassignResourcesFromSubarray = function (sub_nr, resources) {
+        api.unassignResourcesFromSubarray = function(sub_nr, resources) {
             api.handleRequestResponse($http(createRequest('post', urlBase() + '/subarray/' + sub_nr + '/unassign-resource/' + resources)));
         };
 
-        api.activateSubarray = function (sub_nr) {
+        api.activateSubarray = function(sub_nr) {
             return $http(createRequest('post', urlBase() + '/subarray/' + sub_nr + '/activate'), true);
         };
 
-        api.setSubarrayMaintenance = function (sub_nr, maintenance) {
+        api.setSubarrayMaintenance = function(sub_nr, maintenance) {
             api.handleRequestResponse($http(createRequest('post', urlBase() + '/subarray/' + sub_nr + '/maintenance/' + maintenance)));
         };
 
-        api.freeSubarray = function (sub_nr) {
+        api.freeSubarray = function(sub_nr) {
             return api.handleRequestResponse($http(createRequest('post', urlBase() + '/subarray/' + sub_nr + '/free')), true);
         };
 
-        api.getScheduleBlocks = function () {
+        api.getScheduleBlocks = function() {
             //TODO smoothly combine the existing list with the new list so that there isnt a screen flicker
             api.scheduleDraftData.splice(0, api.scheduleDraftData.length);
             $http(createRequest('get', urlBase() + '/sb/approved'))
-                .then(function (result) {
+                .then(function(result) {
                     var jsonResult = JSON.parse(result.data.result);
                     for (var i in jsonResult) {
                         if (api.draftArrayStates.indexOf(jsonResult[i].state) > -1) {
                             api.scheduleDraftData.push(jsonResult[i]);
                         }
                     }
-                }, function (error) {
+                }, function(error) {
                     $log.error(error);
                 });
         };
 
-        api.getProgramBlocks = function () {
+        api.getProgramBlocks = function() {
             var deferred = $q.defer();
             $http(createRequest('get', urlBase() + '/pb'))
-                .then(function (result) {
+                .then(function(result) {
                     var jsonResult = JSON.parse(result.data.result);
                     var newPBIds = [];
                     for (var i in jsonResult) {
-                        var existingPBIndex = _.findIndex(api.programBlocks, {pb_id: jsonResult[i].pb_id});
+                        var existingPBIndex = _.findIndex(api.programBlocks, {
+                            pb_id: jsonResult[i].pb_id
+                        });
                         if (existingPBIndex > -1) {
                             //Update existing program blocks
                             api.programBlocks.splice(existingPBIndex, 1);
@@ -271,12 +282,12 @@
                         newPBIds.push(jsonResult[i].pb_id);
                     }
                     //Remove old program blocks that has had a state change
-                    var existingPBIDs = api.programBlocks.map(function (pb) {
+                    var existingPBIDs = api.programBlocks.map(function(pb) {
                         return pb.pb_id;
                     });
                     var PBIDsToRemove = _.difference(existingPBIDs, newPBIds);
-                    PBIDsToRemove.forEach(function (pbID) {
-                        var existingPBIndex = _.findIndex(api.programBlocks, function (pb) {
+                    PBIDsToRemove.forEach(function(pbID) {
+                        var existingPBIndex = _.findIndex(api.programBlocks, function(pb) {
                             return pb.pb_id === pbID;
                         });
                         if (existingPBIndex > -1) {
@@ -285,29 +296,71 @@
                     });
 
                     deferred.resolve(api.programBlocks);
-                }, function (error) {
+                }, function(error) {
                     $log.error(error);
                     deferred.reject(error);
                 });
             return deferred.promise;
         };
 
-        api.getScheduleBlockDetails = function (idCodes) {
+        api.getScheduleBlockDetails = function(idCodes) {
             return $http(createRequest('post',
-                urlBase() + '/sb/details',
-                {
+                urlBase() + '/sb/details', {
                     id_codes: idCodes.join(',')
                 }));
         };
 
-        api.getScheduledScheduleBlocks = function () {
+        api.getProgramBlocksObservationSchedule = function() {
+            var deferred = $q.defer();
+            $http(createRequest('get', urlBase() + '/pb/observation-schedule'))
+                .then(function(result) {
+                    var jsonResult = JSON.parse(result.data.result);
+                    var newObsSchedItemIds = [];
+                    jsonResult.forEach(function (jsonItem) {
+                        var existingItemIndex = _.findIndex(api.observationSchedule, function (item) {
+                             // this is a program block
+                            return item.schedule_blocks && item.pb_id === jsonItem.pb_id;
+                        });
+                        if (existingItemIndex > -1) {
+                            //Update existing schedule blocks
+                            api.observationSchedule[existingItemIndex] = jsonItem;
+                        } else {
+                            api.observationSchedule.push(jsonItem);
+                        }
+                        newObsSchedItemIds.push(jsonItem.pb_id);
+                    });
+                    // // //Remove old schedule blocks that has had a state change
+                    // var existingItemIndexes = api.scheduleData.map(function(item) {
+                    //     return item.schedule_blocks? item.pb_id : -1;
+                    // });
+                    // var itemIdsToRemove = _.difference(existingItemIndexes, newObsSchedItemIds);
+                    // sbIdCodesToRemove.forEach(function(sbIdCode) {
+                    //     var existingSbIndex = _.findIndex(api.scheduleData, function(sb) {
+                    //         return sb.id_code === sbIdCode;
+                    //     });
+                    //     if (existingSbIndex > -1) {
+                    //         api.scheduleData.splice(existingSbIndex, 1);
+                    //     }
+                    // });
+
+                    // deferred.resolve(api.scheduleData);
+                }, function(error) {
+                    $log.error(error);
+                    deferred.reject(error);
+                });
+            return deferred.promise;
+        };
+
+        api.getScheduledScheduleBlocks = function() {
             var deferred = $q.defer();
             $http(createRequest('get', urlBase() + '/sb/scheduled'))
-                .then(function (result) {
+                .then(function(result) {
                     var jsonResult = JSON.parse(result.data.result);
                     var newScheduleDataIdCodes = [];
                     for (var i in jsonResult) {
-                        var existingSbIndex = _.findIndex(api.scheduleData, {id_code: jsonResult[i].id_code});
+                        var existingSbIndex = _.findIndex(api.scheduleData, {
+                            id_code: jsonResult[i].id_code
+                        });
                         if (existingSbIndex > -1) {
                             //Update existing schedule blocks
                             api.scheduleData.splice(existingSbIndex, 1);
@@ -316,12 +369,12 @@
                         newScheduleDataIdCodes.push(jsonResult[i].id_code);
                     }
                     //Remove old schedule blocks that has had a state change
-                    var existingSbIdCodes = api.scheduleData.map(function (sb) {
+                    var existingSbIdCodes = api.scheduleData.map(function(sb) {
                         return sb.id_code;
                     });
                     var sbIdCodesToRemove = _.difference(existingSbIdCodes, newScheduleDataIdCodes);
-                    sbIdCodesToRemove.forEach(function (sbIdCode) {
-                        var existingSbIndex = _.findIndex(api.scheduleData, function (sb) {
+                    sbIdCodesToRemove.forEach(function(sbIdCode) {
+                        var existingSbIndex = _.findIndex(api.scheduleData, function(sb) {
                             return sb.id_code === sbIdCode;
                         });
                         if (existingSbIndex > -1) {
@@ -330,7 +383,7 @@
                     });
 
                     deferred.resolve(api.scheduleData);
-                }, function (error) {
+                }, function(error) {
                     $log.error(error);
                     deferred.reject(error);
                 });
@@ -338,26 +391,27 @@
         };
 
         api.debounceGetScheduledScheduleBlocks = _.debounce(api.getScheduledScheduleBlocks, 1000);
+        api.debounceGetProgramBlocksObservationSchedule = _.debounce(api.getProgramBlocksObservationSchedule, 1000);
 
-        api.getCompletedScheduleBlocks = function (sub_nr, max_nr) {
+        api.getCompletedScheduleBlocks = function(sub_nr, max_nr) {
             //TODO smoothly combine the existing list with the new list so that there isnt a screen flicker
             api.scheduleCompletedData.splice(0, api.scheduleCompletedData.length);
             $http(createRequest('get', urlBase() + '/sb/completed/' + sub_nr + '/' + max_nr))
-                .then(function (result) {
+                .then(function(result) {
                     var jsonResult = JSON.parse(result.data.result);
                     for (var i in jsonResult) {
                         api.scheduleCompletedData.push(jsonResult[i]);
                     }
-                }, function (error) {
+                }, function(error) {
                     $log.error(error);
                 });
         };
 
-        api.setSchedulerModeForSubarray = function (sub_nr, mode) {
+        api.setSchedulerModeForSubarray = function(sub_nr, mode) {
             api.handleRequestResponse($http(createRequest('post', urlBase() + '/subarray/' + sub_nr + '/sched-mode/' + mode)));
         };
 
-        api.updateScheduleDraft = function (scheduleBlockDraft) {
+        api.updateScheduleDraft = function(scheduleBlockDraft) {
             return $http(createRequest('post', urlBase() + '/sb/' + scheduleBlockDraft.id_code, {
                 id_code: scheduleBlockDraft.id_code,
                 type: scheduleBlockDraft.type,
@@ -367,15 +421,17 @@
             }));
         };
 
-        api.receivedResourceMessage = function (sensor) {
+        api.receivedResourceMessage = function(sensor) {
             var sensorName = sensor.name;
 
             if (sensorName.startsWith('subarray_')) {
-                var subarrayIndex = _.findIndex(api.subarrays, function (item) {
+                var subarrayIndex = _.findIndex(api.subarrays, function(item) {
                     return item.id === sensorName.split('_')[1];
                 });
                 if (subarrayIndex === -1) {
-                    api.subarrays.push({id: sensorName.split('_')[1]});
+                    api.subarrays.push({
+                        id: sensorName.split('_')[1]
+                    });
                     subarrayIndex = api.subarrays.length - 1;
                 }
                 if (subarrayIndex > -1) {
@@ -385,12 +441,14 @@
                         if (!api.subarrays[subarrayIndex].allocations) {
                             api.subarrays[subarrayIndex].allocations = [];
                         } else {
-                           api.subarrays[subarrayIndex].allocations.splice(0, api.subarrays[subarrayIndex].allocations.length);
+                            api.subarrays[subarrayIndex].allocations.splice(0, api.subarrays[subarrayIndex].allocations.length);
                         }
                         if (parsedAllocations.length > 0) {
                             for (var m in parsedAllocations) {
-                                api.subarrays[subarrayIndex].allocations.push(
-                                    {name: parsedAllocations[m][0], allocation: parsedAllocations[m][1]});
+                                api.subarrays[subarrayIndex].allocations.push({
+                                    name: parsedAllocations[m][0],
+                                    allocation: parsedAllocations[m][1]
+                                });
                             }
                         }
                     } else if (sensorName.endsWith('delegated_ca')) {
@@ -409,10 +467,10 @@
                         }
                         if (sensorName.endsWith('state')) {
                             //wait a while to make sure on initial load that we get all the subarray sensor values
-                            $timeout(function () {
+                            $timeout(function() {
                                 if (api.subarrays[subarrayIndex].state !== 'inactive') {
                                     $localStorage.lastKnownSubarrayConfig['subarray_' + api.subarrays[subarrayIndex].id] = {
-                                        allocations: api.subarrays[subarrayIndex].allocations.map(function (resource) {
+                                        allocations: api.subarrays[subarrayIndex].allocations.map(function(resource) {
                                             return resource.name;
                                         }).join(","),
                                         band: api.subarrays[subarrayIndex].band,
@@ -431,12 +489,16 @@
                 var resourcesList = sensor.value.split(',');
                 if (resourcesList.length > 0 && resourcesList[0] !== '') {
                     for (var index in resourcesList) {
-                        api.poolResourcesFree.push({name: resourcesList[index]});
+                        api.poolResourcesFree.push({
+                            name: resourcesList[index]
+                        });
                     }
                 }
             } else if (sensorName.indexOf('mode_') > -1) {
                 var subarrayId = sensorName.split('_')[2];
-                var subarray = _.findWhere(api.subarrays, {id: subarrayId});
+                var subarray = _.findWhere(api.subarrays, {
+                    id: subarrayId
+                });
                 if (subarray) {
                     subarray.mode = sensor.value;
                 }
@@ -446,7 +508,7 @@
             }
         };
 
-        api.receivedScheduleMessage = function (message) {
+        api.receivedScheduleMessage = function(message) {
             var obj = message.value;
             var commandList = message.command.split(' ');
             var table = commandList[0];
@@ -464,13 +526,17 @@
             var pbDataToAdd = [];
 
             if (action === 'delete') {
-                var index = _.findLastIndex(api.programBlocks, {id: parseInt(id_to_action)});
+                var index = _.findLastIndex(api.programBlocks, {
+                    id: parseInt(id_to_action)
+                });
                 if (index > -1) {
                     NotifyService.showSimpleToast('PB ' + api.programBlocks[index].pb_id + ' has been removed');
                     api.programBlocks.splice(index, 1);
                 }
             } else if (action === 'update') {
-                var pbIndex = _.findLastIndex(api.programBlocks, {id: pb.id});
+                var pbIndex = _.findLastIndex(api.programBlocks, {
+                    id: pb.id
+                });
                 if (pbIndex > -1) {
                     var existingSBList = api.programBlocks[pbIndex].schedule_blocks;
                     pb.schedule_blocks = existingSBList;
@@ -487,13 +553,17 @@
             }
         };
 
-        api.updateProgramBlocksWithUpdatedSb = function (sb) {
+        api.updateProgramBlocksWithUpdatedSb = function(sb) {
             if (sb.pb_id) {
-                var pbIndex = _.findLastIndex(api.programBlocks, {id: sb.pb_id});
+                var pbIndex = _.findLastIndex(api.programBlocks, {
+                    id: sb.pb_id
+                });
                 if (pbIndex > -1) {
                     //SB could've moved from one pb to another
-                    api.programBlocks.forEach(function (pb, existingIndex) {
-                        var sbIndex = _.findLastIndex(pb.schedule_blocks, {id: sb.id});
+                    api.programBlocks.forEach(function(pb, existingIndex) {
+                        var sbIndex = _.findLastIndex(pb.schedule_blocks, {
+                            id: sb.id
+                        });
                         if (sbIndex > -1) {
                             api.programBlocks[existingIndex].schedule_blocks.splice(sbIndex, 1);
                         }
@@ -503,11 +573,13 @@
                     }
                 } else {
                     $log.warning('Trying to update program blocks with sb.pb_id: ' + sb.pb_id +
-                                 ', but could not find any program blocks with that id!');
+                        ', but could not find any program blocks with that id!');
                 }
             } else if (!sb.pb_id) {
-                api.programBlocks.forEach(function (pb) {
-                    var sbIndex = _.findLastIndex(pb.schedule_blocks, {id: sb.id});
+                api.programBlocks.forEach(function(pb) {
+                    var sbIndex = _.findLastIndex(pb.schedule_blocks, {
+                        id: sb.id
+                    });
                     if (sbIndex > -1) {
                         pb.schedule_blocks.splice(sbIndex, 1);
                     }
@@ -523,7 +595,9 @@
 
             if (action === 'delete') {
                 //only drafts can be deleted in the db
-                var index = _.findLastIndex(api.scheduleDraftData, {id: parseInt(id_to_action)});
+                var index = _.findLastIndex(api.scheduleDraftData, {
+                    id: parseInt(id_to_action)
+                });
                 if (index > -1) {
                     NotifyService.showSimpleToast('SB ' + api.scheduleDraftData[index].id_code + ' has been removed');
                     if (api.scheduleDraftData[index].pb_id) {
@@ -533,8 +607,12 @@
                     api.scheduleDraftData.splice(index, 1);
                 }
             } else if (action === 'update') {
-                var draftIndex = _.findLastIndex(api.scheduleDraftData, {id: sb.id});
-                var scheduledIndex = _.findLastIndex(api.scheduleData, {id: sb.id});
+                var draftIndex = _.findLastIndex(api.scheduleDraftData, {
+                    id: sb.id
+                });
+                var scheduledIndex = _.findLastIndex(api.scheduleData, {
+                    id: sb.id
+                });
 
                 if (api.draftArrayStates.indexOf(sb.state) > -1) {
                     if (draftIndex > -1) {
@@ -569,7 +647,9 @@
                     // because it means that the states of sb's changed
                     orderChangeCall = true;
                 } else {
-                    var completedIndex = _.findLastIndex(api.scheduleCompletedData, {id: sb.id});
+                    var completedIndex = _.findLastIndex(api.scheduleCompletedData, {
+                        id: sb.id
+                    });
                     if (completedIndex > -1) {
                         if (api.scheduleCompletedData[completedIndex].pb_id !== sb.pb_id) {
                             api.updateProgramBlocksWithUpdatedSb(sb);
@@ -615,6 +695,7 @@
             }
             if (orderChangeCall) {
                 api.debounceGetScheduledScheduleBlocks();
+                api.debounceGetProgramBlocksObservationSchedule();
             }
         };
 
@@ -626,36 +707,36 @@
             }
         }
 
-        api.listConfigLabels = function () {
+        api.listConfigLabels = function() {
             api.configLabels.splice(0, api.configLabels.length);
             $http(createRequest('get', urlBase() + '/config-labels'))
-                .then(function (result) {
+                .then(function(result) {
                     var configLabels = JSON.parse(result.data);
-                    configLabels.forEach(function (item) {
+                    configLabels.forEach(function(item) {
                         api.configLabels.push(item);
                     });
-                }, function (error) {
+                }, function(error) {
                     $log.error(error);
                 });
         };
 
-        api.setConfigLabel = function (sub_nr, config_label) {
+        api.setConfigLabel = function(sub_nr, config_label) {
             api.handleRequestResponse($http(createRequest('post', urlBase() + '/config-labels/' + sub_nr + '/' + config_label)));
         };
 
-        api.setBand = function (sub_nr, band) {
+        api.setBand = function(sub_nr, band) {
             api.handleRequestResponse($http(createRequest('post', urlBase() + '/bands/' + sub_nr + '/' + band)));
         };
 
-        api.setProduct = function (sub_nr, product) {
+        api.setProduct = function(sub_nr, product) {
             api.handleRequestResponse($http(createRequest('post', urlBase() + '/products/' + sub_nr + '/' + product)));
         };
 
-        api.delegateControl = function (sub_nr, userName) {
+        api.delegateControl = function(sub_nr, userName) {
             api.handleRequestResponse($http(createRequest('post', urlBase() + '/subarray/' + sub_nr + '/delegate-control/' + userName)));
         };
 
-        api.viewTaskLogForSBIdCode = function (id_code, mode) {
+        api.viewTaskLogForSBIdCode = function(id_code, mode) {
             if (ConfigService.GetKATTaskFileServerURL()) {
                 window.open(ConfigService.GetKATTaskFileServerURL() + "/tailtask/" + id_code + "/" + mode).focus();
             } else {
@@ -663,7 +744,7 @@
             }
         };
 
-        api.showSubarrayAndDataLogs = function (sub_nr) {
+        api.showSubarrayAndDataLogs = function(sub_nr) {
             if (ConfigService.GetKATTaskFileServerURL()) {
                 window.open(ConfigService.GetKATLogFileServerURL() + "/logfile/kat.katsubarray" + sub_nr + ".log/tail/");
                 window.open(ConfigService.GetKATLogFileServerURL() + "/logfile/kat.data_" + sub_nr + ".log/tail/");
@@ -672,66 +753,65 @@
             }
         };
 
-        api.listResourceMaintenanceDevicesDialog = function (sub_nr, resource, event) {
+        api.listResourceMaintenanceDevicesDialog = function(sub_nr, resource, event) {
             $mdDialog
                 .show({
-                    controller: function ($rootScope, $scope, $mdDialog) {
+                    controller: function($rootScope, $scope, $mdDialog) {
                         $scope.title = 'Select a device in ' + resource + ' to restart';
                         $scope.devices = [];
                         api.listResourceMaintenanceDevices(resource)
-                            .then(function (result) {
+                            .then(function(result) {
                                 var resultList = JSON.parse(result.data.result.replace(/\"/g, '').replace(/\'/g, '"'));
                                 for (var i in resultList) {
                                     $scope.devices.push(resultList[i]);
                                 }
-                            }, function (error) {
+                            }, function(error) {
                                 $log.error(error);
                             });
 
-                        $scope.hide = function () {
+                        $scope.hide = function() {
                             $mdDialog.hide();
                         };
-                        $scope.restartMaintenanceDevice = function (device) {
+                        $scope.restartMaintenanceDevice = function(device) {
                             api.restartMaintenanceDevice(sub_nr, resource, device);
                         };
                     },
-                    template:
-                    '<md-dialog style="padding: 0;" md-theme="{{$root.themePrimary}}">' +
-                    '   <div style="padding: 0; margin: 0; overflow: auto" layout="column">' +
-                    '       <md-toolbar class="md-primary" layout="row" layout-align="center center">' +
-                    '           <span flex style="margin: 16px;">{{::title}}</span>' +
-                    '       </md-toolbar>' +
-                    '       <div flex layout="column">' +
-                    '           <div layout="row" layout-align="center center" ng-repeat="device in devices track by $index">' +
-                    '               <md-button style="margin: 0" flex title="Restart {{device}} Device"' +
-                    '                   ng-click="restartMaintenanceDevice(device); $event.stopPropagation()">' +
-                    '                   <span style="margin-right: 8px;" class="fa fa-refresh"></span>' +
-                    '                   <span>{{device}}</span>' +
-                    '               </md-button>' +
-                    '           </div>' +
-                    '       </div>' +
-                    '       <div layout="row" layout-align="end" style="margin-top: 8px; margin-right: 8px; margin-bottom: 8px; min-height: 40px;">' +
-                    '           <md-button style="margin-left: 8px;" class="md-primary md-raised" md-theme="{{$root.themePrimaryButtons}}" aria-label="OK" ng-click="hide()">Close</md-button>' +
-                    '       </div>' +
-                    '   </div>' +
-                    '</md-dialog>',
+                    template: '<md-dialog style="padding: 0;" md-theme="{{$root.themePrimary}}">' +
+                        '   <div style="padding: 0; margin: 0; overflow: auto" layout="column">' +
+                        '       <md-toolbar class="md-primary" layout="row" layout-align="center center">' +
+                        '           <span flex style="margin: 16px;">{{::title}}</span>' +
+                        '       </md-toolbar>' +
+                        '       <div flex layout="column">' +
+                        '           <div layout="row" layout-align="center center" ng-repeat="device in devices track by $index">' +
+                        '               <md-button style="margin: 0" flex title="Restart {{device}} Device"' +
+                        '                   ng-click="restartMaintenanceDevice(device); $event.stopPropagation()">' +
+                        '                   <span style="margin-right: 8px;" class="fa fa-refresh"></span>' +
+                        '                   <span>{{device}}</span>' +
+                        '               </md-button>' +
+                        '           </div>' +
+                        '       </div>' +
+                        '       <div layout="row" layout-align="end" style="margin-top: 8px; margin-right: 8px; margin-bottom: 8px; min-height: 40px;">' +
+                        '           <md-button style="margin-left: 8px;" class="md-primary md-raised" md-theme="{{$root.themePrimaryButtons}}" aria-label="OK" ng-click="hide()">Close</md-button>' +
+                        '       </div>' +
+                        '   </div>' +
+                        '</md-dialog>',
                     targetEvent: event
                 });
         };
 
-        api.listResourceTemplates = function () {
+        api.listResourceTemplates = function() {
             api.resourceTemplates.splice(0, api.resourceTemplates.length);
             $http.get(urlBase() + '/subarray/template/list')
-                .then(function (result) {
-                    result.data.forEach(function (item) {
+                .then(function(result) {
+                    result.data.forEach(function(item) {
                         api.resourceTemplates.push(item);
                     });
-                }, function (error) {
+                }, function(error) {
                     $log.error(error);
                 });
         };
 
-        api.loadResourceTemplate = function (subarray, template) {
+        api.loadResourceTemplate = function(subarray, template) {
             if (ConfigService.systemConfig.system.bands.indexOf(template.band) === -1) {
                 $log.error('Could not set band ' + template.band + '.');
             } else if (subarray.band !== template.band) {
@@ -745,45 +825,45 @@
             api.assignResourcesToSubarray(subarray.id, template.resources);
         };
 
-        api.addResourceTemplate = function (template) {
+        api.addResourceTemplate = function(template) {
             $http(createRequest('post',
-                urlBase() + '/subarray/template/add',
-                {
-                    name: template.name,
-                    owner: $rootScope.currentUser.email,
-                    resources: template.resources,
-                    band: template.band,
-                    product: template.product
-                }))
-                .then(function (result) {
+                    urlBase() + '/subarray/template/add', {
+                        name: template.name,
+                        owner: $rootScope.currentUser.email,
+                        resources: template.resources,
+                        band: template.band,
+                        product: template.product
+                    }))
+                .then(function(result) {
                     api.resourceTemplates.push(result.data);
                     NotifyService.showSimpleToast("Created resource template");
-                }, function (error) {
+                }, function(error) {
                     NotifyService.showHttpErrorDialog('Error creating resource template', error);
                 });
         };
 
-        api.modifyResourceTemplate = function (template) {
+        api.modifyResourceTemplate = function(template) {
             $http(createRequest('post',
-                urlBase() + '/subarray/template/modify/' + template.id,
-                {
-                    name: template.name,
-                    owner: $rootScope.currentUser.email,
-                    resources: template.resources,
-                    band: template.band,
-                    product: template.product,
-                    activated: template.activated
-                }))
-                .then(function (result) {
-                    var oldResource = _.findWhere(api.resourceTemplates, {id: template.id});
+                    urlBase() + '/subarray/template/modify/' + template.id, {
+                        name: template.name,
+                        owner: $rootScope.currentUser.email,
+                        resources: template.resources,
+                        band: template.band,
+                        product: template.product,
+                        activated: template.activated
+                    }))
+                .then(function(result) {
+                    var oldResource = _.findWhere(api.resourceTemplates, {
+                        id: template.id
+                    });
                     oldResource = result.data;
                     NotifyService.showSimpleToast("Modified resource template");
-                }, function (error) {
+                }, function(error) {
                     NotifyService.showHttpErrorDialog('Error modifying resource template', error);
                 });
         };
 
-        api.sbProgress = function (sb) {
+        api.sbProgress = function(sb) {
             var startDate = moment.utc(sb.actual_start_time);
             var startDateTime = startDate.toDate().getTime();
             var endDate = moment.utc(startDate).add(sb.expected_duration_seconds, 'seconds');
@@ -791,19 +871,19 @@
             return (now.toDate().getTime() - startDateTime) / (endDate.toDate().getTime() - startDateTime) * 100;
         };
 
-        api.getLastKnownSubarrayConfig = function (subarrayNumber) {
+        api.getLastKnownSubarrayConfig = function(subarrayNumber) {
             api.lastKnownSubarrayConfig['subarray_' + subarrayNumber] = $localStorage.lastKnownSubarrayConfig['subarray_' + subarrayNumber];
             return api.lastKnownSubarrayConfig['subarray_' + subarrayNumber];
         };
 
-        api.loadLastKnownSubarrayConfig = function (subarrayNumber) {
+        api.loadLastKnownSubarrayConfig = function(subarrayNumber) {
             var lastKnownConfig = $localStorage.lastKnownSubarrayConfig['subarray_' + subarrayNumber];
             if (lastKnownConfig) {
-                var subarray = _.find(api.subarrays, function (item) {
+                var subarray = _.find(api.subarrays, function(item) {
                     return item.id === subarrayNumber;
                 });
                 if (lastKnownConfig.allocations) {
-                    var currentAllocations = subarray.allocations.map(function (resource) {
+                    var currentAllocations = subarray.allocations.map(function(resource) {
                         return resource.name;
                     });
                     var resourcesToAllocate = lastKnownConfig.allocations.split(',');
@@ -821,40 +901,38 @@
             }
         };
 
-        api.setupSubarrayFromPB = function (subarrayNumber, pb_id, event) {
+        api.setupSubarrayFromPB = function(subarrayNumber, pb_id, event) {
             $http(createRequest('post', urlBase() + '/subarray/' + subarrayNumber + '/setup/' + pb_id))
-                .then(function (result) {
+                .then(function(result) {
                     NotifyService.showSetupSubarrayDialog(
                         event, "Setup Subarray " + subarrayNumber + " results", result.data.results, subarrayNumber);
-                }, function (error) {
+                }, function(error) {
                     $log.info(error);
                     NotifyService.showHttpErrorDialog('Error setting up subarray from PB', error);
                 });
         };
 
-        api.updateSBOrderingValues = function (id_code, lead_operator_priority, sb_order, sb_sequence) {
+        api.updateSBOrderingValues = function(id_code, lead_operator_priority, sb_order, sb_sequence) {
             return $http(createRequest('post',
-                urlBase() + '/sb/' + id_code + '/order',
-                {
+                urlBase() + '/sb/' + id_code + '/order', {
                     lead_operator_priority: lead_operator_priority,
                     sb_order: sb_order,
                     sb_sequence: sb_sequence,
                 }));
         };
 
-        api.updatePBOrderingValues = function (pb_id, director_priority, pb_order, pb_sequence) {
+        api.updatePBOrderingValues = function(pb_id, director_priority, pb_order, pb_sequence) {
             return $http(createRequest('post',
-                urlBase() + '/pb/' + pb_id + '/order',
-                {
+                urlBase() + '/pb/' + pb_id + '/order', {
                     director_priority: director_priority,
                     pb_order: pb_order,
                     pb_sequence: pb_sequence,
                 }));
         };
 
-        api.progressInterval = $interval(function () {
+        api.progressInterval = $interval(function() {
             if (api.scheduleData.length > 0) {
-                api.scheduleData.forEach(function (sb) {
+                api.scheduleData.forEach(function(sb) {
                     if (sb.state === 'ACTIVE' && sb.expected_duration_seconds && sb.actual_start_time) {
                         sb.progress = api.sbProgress(sb);
                     }

--- a/app/services/obs-sched-service.js
+++ b/app/services/obs-sched-service.js
@@ -314,36 +314,12 @@
             var deferred = $q.defer();
             $http(createRequest('get', urlBase() + '/pb/observation-schedule'))
                 .then(function(result) {
+                    api.observationSchedule.splice(0, api.observationSchedule.length);
                     var jsonResult = JSON.parse(result.data.result);
-                    var newObsSchedItemIds = [];
                     jsonResult.forEach(function (jsonItem) {
-                        var existingItemIndex = _.findIndex(api.observationSchedule, function (item) {
-                             // this is a program block
-                            return item.schedule_blocks && item.pb_id === jsonItem.pb_id;
-                        });
-                        if (existingItemIndex > -1) {
-                            //Update existing schedule blocks
-                            api.observationSchedule[existingItemIndex] = jsonItem;
-                        } else {
-                            api.observationSchedule.push(jsonItem);
-                        }
-                        newObsSchedItemIds.push(jsonItem.pb_id);
+                        api.observationSchedule.push(jsonItem);
                     });
-                    // // //Remove old schedule blocks that has had a state change
-                    // var existingItemIndexes = api.scheduleData.map(function(item) {
-                    //     return item.schedule_blocks? item.pb_id : -1;
-                    // });
-                    // var itemIdsToRemove = _.difference(existingItemIndexes, newObsSchedItemIds);
-                    // sbIdCodesToRemove.forEach(function(sbIdCode) {
-                    //     var existingSbIndex = _.findIndex(api.scheduleData, function(sb) {
-                    //         return sb.id_code === sbIdCode;
-                    //     });
-                    //     if (existingSbIndex > -1) {
-                    //         api.scheduleData.splice(existingSbIndex, 1);
-                    //     }
-                    // });
-
-                    // deferred.resolve(api.scheduleData);
+                    deferred.resolve(api.observationSchedule);
                 }, function(error) {
                     $log.error(error);
                     deferred.reject(error);

--- a/app/services/obs-sched-service.js
+++ b/app/services/obs-sched-service.js
@@ -492,10 +492,10 @@
                 var pbIndex = _.findLastIndex(api.programBlocks, {id: sb.pb_id});
                 if (pbIndex > -1) {
                     //SB could've moved from one pb to another
-                    api.programBlocks.forEach(function (pb) {
-                        var sbIndex = _.findLastIndex(api.programBlocks[pbIndex].schedule_blocks, {id: sb.id});
+                    api.programBlocks.forEach(function (pb, existingIndex) {
+                        var sbIndex = _.findLastIndex(pb.schedule_blocks, {id: sb.id});
                         if (sbIndex > -1) {
-                            api.programBlocks[pbIndex].schedule_blocks.splice(sbIndex, 1);
+                            api.programBlocks[existingIndex].schedule_blocks.splice(sbIndex, 1);
                         }
                     });
                     if (!sb.deleted) {
@@ -830,6 +830,26 @@
                     $log.info(error);
                     NotifyService.showHttpErrorDialog('Error setting up subarray from PB', error);
                 });
+        };
+
+        api.updateSBOrderingValues = function (id_code, lead_operator_priority, sb_order, sb_sequence) {
+            return $http(createRequest('post',
+                urlBase() + '/sb/' + id_code + '/order',
+                {
+                    lead_operator_priority: lead_operator_priority,
+                    sb_order: sb_order,
+                    sb_sequence: sb_sequence,
+                }));
+        };
+
+        api.updatePBOrderingValues = function (pb_id, director_priority, pb_order, pb_sequence) {
+            return $http(createRequest('post',
+                urlBase() + '/pb/' + pb_id + '/order',
+                {
+                    director_priority: director_priority,
+                    pb_order: pb_order,
+                    pb_sequence: pb_sequence,
+                }));
         };
 
         api.progressInterval = $interval(function () {

--- a/app/services/obs-sched-service.js
+++ b/app/services/obs-sched-service.js
@@ -610,7 +610,6 @@
                 if (api.draftArrayStates.indexOf(sb.state) > -1) {
                     if (draftIndex > -1) {
                         if (api.scheduleDraftData[draftIndex].pb_id !== sb.pb_id) {
-                            api.updateProgramBlocksWithUpdatedSb(sb);
                         }
                         api.scheduleDraftData[draftIndex] = sb;
                     } else if (draftIndex === -1) {
@@ -620,16 +619,11 @@
                             $rootScope.$emit('sb_schedule_remove', sb);
                             orderChangeCall = true;
                         }
-                        if (sb.pb_id) {
-                            api.updateProgramBlocksWithUpdatedSb(sb);
-                        }
                         draftDataToAdd.push(sb);
                     }
+
                 } else if (sb.state === 'SCHEDULED' || sb.state === 'ACTIVE') {
                     if (scheduledIndex > -1) {
-                        if (api.scheduleData[scheduledIndex].pb_id !== sb.pb_id) {
-                            api.updateProgramBlocksWithUpdatedSb(sb);
-                        }
                         api.scheduleData[scheduledIndex] = sb;
                         $rootScope.$emit('sb_schedule_update', sb);
 
@@ -644,9 +638,6 @@
                         id: sb.id
                     });
                     if (completedIndex > -1) {
-                        if (api.scheduleCompletedData[completedIndex].pb_id !== sb.pb_id) {
-                            api.updateProgramBlocksWithUpdatedSb(sb);
-                        }
                         api.scheduleCompletedData[completedIndex] = sb;
                     } else if (scheduledIndex > -1) {
                         api.scheduleData.splice(scheduledIndex, 1);
@@ -659,6 +650,7 @@
                         completedDataToAdd.push(sb);
                     }
                 }
+                api.updateProgramBlocksWithUpdatedSb(sb);
             } else if (action === 'insert') {
                 if (api.draftArrayStates.indexOf(sb.state) > -1) {
                     draftDataToAdd.push(sb);

--- a/app/widgets/activity/activity-widget.js
+++ b/app/widgets/activity/activity-widget.js
@@ -26,6 +26,8 @@
 
         //TODO this needs a promise
         ObsSchedService.getScheduledScheduleBlocks();
+        //TODO program blocks
+        // ObsSchedService.getProgramBlocksObservationSchedule();
         MonitorService.subscribe('sched');
         MonitorService.subscribe('userlogs');
 
@@ -101,6 +103,7 @@
 
         var unbindOrderChangeAdd = $rootScope.$on('sb_order_change', function(event, sb) {
             //TODO this needs a promise
+            // TODO program blocks
             ObsSchedService.getScheduledScheduleBlocks();
             $timeout(function() {
                 vm.addSbsToTimeline(ObsSchedService.scheduleData);

--- a/index.html
+++ b/index.html
@@ -338,7 +338,7 @@
                 <span flex style="font-size: 30px; cursor: pointer;" title="Click to Navigate to Parent Display" ng-click="vm.navigateToParentState()">{{$root.currentStateTitle()}}</span>
                 <div layout="column" layout-align="start center" style="margin-right: 8px">
                     <md-menu style="padding: 0;">
-                        <md-button style="margin: 0; text-transform: none; font-size: 18px" ng-click="$mdOpenMenu()">
+                        <md-button style="margin: 0; text-transform: none; font-size: 18px" ng-click="$mdMenu.open($event)">
                             <span>{{$root.currentUser.email}}</span><i style="font-size: 12px"> ({{$root.rolesMap[$root.currentUser.req_role]}})</i>
                             <span style="font-size: 14px" class="fa fa-caret-down"></span>
                         </md-button>


### PR DESCRIPTION
This PR relates to the feature described in ska-sa/katcorelib#217. This one specifically requires https://github.com/ska-sa/katportal/pull/257 to be merged. For integration tests, https://github.com/ska-sa/katscripts/pull/104 needs to be merged with this PR.

Please do not merge this PR, just review. Then I will merge all the related PR's at the same time when all comments have been addressed in each PR.

Lots of refactoring done to allow for displaying of program blocks as the observation schedule display. Here's a couple of screenshots instead of a wall of text:

<img width="639" alt="screen shot 2017-02-24 at 1 58 31 pm" src="https://cloud.githubusercontent.com/assets/8371143/23303983/0d7b8b90-faa0-11e6-9129-33c42993de40.png">
<img width="639" alt="screen shot 2017-02-24 at 1 58 31 pm" 
src="https://cloud.githubusercontent.com/assets/8371143/23304049/6a34c3c4-faa0-11e6-81fe-7bf215f6b8b4.png">
<img width="639" alt="screen shot 2017-02-24 at 1 58 31 pm" src="https://cloud.githubusercontent.com/assets/8371143/23304056/71a8f706-faa0-11e6-854c-a03f27b4e07a.png">
<img width="639" alt="screen shot 2017-02-24 at 1 58 31 pm" src="https://cloud.githubusercontent.com/assets/8371143/23304059/744dfc68-faa0-11e6-9bbb-c462ead34eb2.png">
<img width="639" alt="screen shot 2017-02-24 at 1 58 31 pm" src="https://cloud.githubusercontent.com/assets/8371143/23304063/77cec624-faa0-11e6-8cf6-d8a8ebd61cbc.png">
