### PR TITLE
only match on title when overwriting existing gui urls for resources

### DIFF
--- a/app/services/obs-sched-service.js
+++ b/app/services/obs-sched-service.js
@@ -491,7 +491,7 @@
                         api.guiUrls[resourceName] = guiUrls;
                     } else {
                         guiUrls.value.forEach(function (guiUrl) {
-                            var existingUrlIndex = _.findIndex(api.guiUrls[resourceName].value, {title: guiUrl.title, href: guiUrl.href});
+                            var existingUrlIndex = _.findIndex(api.guiUrls[resourceName].value, {title: guiUrl.title});
                             if (existingUrlIndex > -1) {
                                 api.guiUrls[resourceName].value[existingUrlIndex] = guiUrl;
                             } else {


### PR DESCRIPTION
This prevents duplicate gui links on the scheduler display when a subarray activates and the url of an existing cached gui url changes to something new.