### PR TITLE
Correctly disable clicking when logging in as a CA and not allowed to control a subarray

### DIFF
--- a/app/health/templates/receptor-block-container-repeat.html
+++ b/app/health/templates/receptor-block-container-repeat.html
@@ -10,9 +10,9 @@
     </div>
     <div style="position: absolute; top: 0; right: 0; width: 22px">
         <span class="icon-button fa fa-wrench" md-ink-ripple ng-disabled="!$root.expertOrLO" title="Mark Receptor in Maintenance"
-            ng-class="{'maintenance-text opaque': receptor.maintenance}" ng-click="vm.markResourceInMaintenance(receptor); $event.stopPropagation()"></span>
+            ng-class="{'maintenance-text opaque': receptor.maintenance}" ng-click="!$root.expertOrLO || vm.markResourceInMaintenance(receptor); $event.stopPropagation()"></span>
         <span class="icon-button fa" md-ink-ripple ng-disabled="!$root.expertOrLO" title="Mark Receptor As Faulty"
             ng-mousedown="$event.stopPropagation()" ng-class="{'fa-exclamation-circle': !receptor.faulty, 'fa-warning error-text opaque': receptor.faulty}"
-            ng-click="vm.markResourceFaulty(receptor); $event.stopPropagation()"></span>
+            ng-click="!$root.expertOrLO || vm.markResourceFaulty(receptor); $event.stopPropagation()"></span>
     </div>
 </div>

--- a/app/health/templates/receptor-svg-container-repeat.html
+++ b/app/health/templates/receptor-svg-container-repeat.html
@@ -10,9 +10,9 @@
 
     <div style="position: absolute; top: 0; right: 0; width: 26px">
         <span class="icon-button fa fa-wrench" md-ink-ripple ng-disabled="!$root.expertOrLO" title="Mark Receptor in Maintenance"
-            ng-class="{'maintenance-text opaque': receptor.maintenance}" ng-click="vm.markResourceInMaintenance(receptor); $event.stopPropagation()"></span>
+            ng-class="{'maintenance-text opaque': receptor.maintenance}" ng-click="!$root.expertOrLO || vm.markResourceInMaintenance(receptor); $event.stopPropagation()"></span>
         <span class="icon-button fa" md-ink-ripple ng-disabled="!$root.expertOrLO" title="Mark Receptor As Faulty"
             ng-mousedown="$event.stopPropagation()" ng-class="{'fa-exclamation-circle': !receptor.faulty, 'fa-warning error-text opaque': receptor.faulty}"
-            ng-click="vm.markResourceFaulty(receptor); $event.stopPropagation()"></span>
+            ng-click="!$root.expertOrLO || vm.markResourceFaulty(receptor); $event.stopPropagation()"></span>
     </div>
 </div>

--- a/app/scheduler/observations/observations-detail.html
+++ b/app/scheduler/observations/observations-detail.html
@@ -139,10 +139,10 @@
                 </div>
                 <span style="width: 18px; padding: 6px 0" class="icon-button fa fa-refresh" ng-disabled="!$root.expertOrLO"
                     md-ink-ripple ng-show="resource.maintenance && vm.subarray.maintenance" title="Restart Maintenance Device"
-                    ng-click="parent.vm.listResourceMaintenanceDevicesDialog(resource, $event); $event.stopPropagation()"></span>
-                <span style="width: 18px; padding: 6px 0" class="icon-button fa" ng-disabled="!$root.expertOrLO" md-ink-ripple
+                    ng-click="!$root.expertOrLO || parent.vm.listResourceMaintenanceDevicesDialog(resource, $event); $event.stopPropagation()"></span>
+                <span style="width: 18px; padding: 6px 0" class="icon-button fa" ng-disabled="!parent.vm.iAmAtLeastCA()" md-ink-ripple
                     title="Mark Resource As Faulty" ng-class="{'fa-exclamation-circle': !resource.faulty, 'fa-warning error-text opaque': resource.faulty}"
-                    ng-click="parent.vm.markResourceFaulty(resource); $event.stopPropagation()"></span>
+                    ng-click="!parent.vm.iAmAtLeastCA() || parent.vm.markResourceFaulty(resource); $event.stopPropagation()"></span>
             </div>
         </div>
         <md-toolbar style="margin-left: 0; width: 450px; position: relative; margin-top: 8px" class="panel-toolbar-small md-whiteframe-z1">

--- a/app/scheduler/schedule-block-drafts/schedule-block-drafts.html
+++ b/app/scheduler/schedule-block-drafts/schedule-block-drafts.html
@@ -6,7 +6,7 @@
                 <div layout="row" class="unselectable">
                     <span flex style="max-height: 10px;"></span>
                     <input class="fade-in search-input-box" type="search" ng-model-options="{ debounce: 300 }" ng-model="vm.q"
-                        placeholder="Search Drafts..." />
+                        placeholder="Search Approved..." />
                     <span class="icon-button fa fa-check" style="font-size: 16px" md-ink-ripple title="Save all changes"
                         ng-click="vm.saveAllDirtyDrafts()"></span>
                 </div>
@@ -65,7 +65,7 @@
                     <span class="icon-button fa fa-check" md-ink-ripple title="Save Edits" ng-click="vm.saveDraft(item); $event.stopPropagation()"
                         ng-if="item.editing"></span>
                     <span ng-disabled="!$root.expertOrLO && $root.currentUser.req_role !== 'control_authority'" class="icon-button fa fa-remove"
-                        md-ink-ripple title="Delete Draft Schedule Block" ng-click="vm.removeDraft(item); $event.stopPropagation()"
+                        md-ink-ripple title="Delete Approved Schedule Block" ng-click="!$root.expertOrLO && $root.currentUser.req_role !== 'control_authority' || vm.removeDraft(item); $event.stopPropagation()"
                         ng-if="!item.editing"></span>
                     <md-menu>
                         <span class="icon-button fa fa-ellipsis-v" md-ink-ripple style="padding: 6px" ng-click="$mdMenu.open($event); $event.stopPropagation()"></span>

--- a/app/scheduler/scheduler-home.js
+++ b/app/scheduler/scheduler-home.js
@@ -390,7 +390,9 @@
         };
 
         vm.cancelExecuteSchedule = function(item) {
-            ObsSchedService.cancelExecuteSchedule(item.sub_nr, item.id_code);
+            if (vm.iAmAtLeastCA() && item.state === 'ACTIVE') {
+                ObsSchedService.cancelExecuteSchedule(item.sub_nr, item.id_code);
+            }
         };
 
         vm.cloneSB = function(item) {

--- a/app/scheduler/subarray-resources/subarray-resources.html
+++ b/app/scheduler/subarray-resources/subarray-resources.html
@@ -118,13 +118,13 @@
                                 <a ng-repeat="link in parent.vm.guiUrls[resource.name].value track by $index" href="{{link.href}}" title="{{link.description}}" style="padding: 0">{{link.title}}</a>
                             </div>
                             <span class="icon-button fa fa-refresh" ng-disabled="!$root.expertOrLO" md-ink-ripple ng-show="resource.maintenance && vm.subarray.maintenance"
-                                title="Restart Maintenance Device" ng-click="parent.vm.listResourceMaintenanceDevicesDialog(resource, $event); $event.stopPropagation()"></span>
+                                title="Restart Maintenance Device" ng-click="!$root.expertOrLO || parent.vm.listResourceMaintenanceDevicesDialog(resource, $event); $event.stopPropagation()"></span>
                             <span md-ink-ripple ng-click="parent.vm.showResourceLogs(resource.name)" class="icon-button fa fa-file-text-o" title="{{'Show ' + resource.name + ' logs'}}"></span>
-                            <span class="icon-button fa" ng-disabled="!$root.expertOrLO" md-ink-ripple title="Mark Resource As Faulty"
+                            <span class="icon-button fa" ng-disabled="!parent.vm.iAmAtLeastCA()" md-ink-ripple title="Mark Resource As Faulty"
                                 ng-class="{'fa-exclamation-circle': !resource.faulty, 'fa-warning error-text opaque': resource.faulty}"
-                                ng-click="parent.vm.markResourceFaulty(resource); $event.stopPropagation()"></span>
+                                ng-click="!parent.vm.iAmAtLeastCA() || parent.vm.markResourceFaulty(resource); $event.stopPropagation()"></span>
                             <span class="icon-button fa fa-chevron-right" ng-disabled="!$root.expertOrLO" md-ink-ripple title="Free Assigned Resource"
-                                ng-click="vm.freeAssignedResource(resource); $event.stopPropagation()"></span>
+                                ng-click="!$root.expertOrLO || vm.freeAssignedResource(resource); $event.stopPropagation()"></span>
                         </div>
                     </div>
                 </div>
@@ -148,7 +148,7 @@
                         [esc] to clear selection, [enter] to assign resources
                     </md-tooltip>
                     <span flex class="md-toolbar-tools" title="Click to select or deselect all free resources" style="cursor: pointer; max-height: 32px; padding: 0 4px"
-                        ng-click="vm.selectAllUnassignedResources(vm.selectedResources.length === 0)">Free Resources</span>
+                        ng-click="!$root.expertOrLO || vm.selectAllUnassignedResources(vm.selectedResources.length === 0)">Free Resources</span>
                     <input class="search-input-box unselectable" type="search" style="width: 140px;" ng-model-options="{ debounce: 300 }"
                         ng-model="vm.q" placeholder="Search Resources..." />
                 </md-toolbar>
@@ -159,14 +159,14 @@
                         ng-disabled="!$root.expertOrLO" ng-mousedown="vm.dragSelect = true; vm.dragSelectUnselect = resource.selected; vm.toggleResourceSelect(resource)"
                         ng-mouseover="vm.dragSelect && !vm.dragSelectUnselect? vm.toggleResourceSelect(resource, true) : vm.dragSelect && vm.dragSelectUnselect? vm.toggleResourceSelect(resource, false) : ''">
                         <span md-ink-ripple class="icon-button fa fa-chevron-left" ng-disabled="!$root.expertOrLO" title="Assign to Subarray"
-                            ng-mousedown="$event.stopPropagation()" ng-click="vm.assignResource(resource); $event.stopPropagation()"></span>
+                            ng-mousedown="$event.stopPropagation()" ng-click="!$root.expertOrLO || vm.assignResource(resource); $event.stopPropagation()"></span>
                         <span flex style="font-size:18px; margin-left: 4px;" class="resource-name" ng-class="{'maintenance-text': resource.maintenance}">{{resource.name}}</span>
                         <span class="icon-button fa fa-wrench" md-ink-ripple ng-disabled="!$root.expertOrLO" title="Mark Resource in Maintenance"
                             ng-class="{'maintenance-text opaque': resource.maintenance}" ng-mousedown="$event.stopPropagation()"
-                            ng-click="parent.vm.markResourceInMaintenance(resource); $event.stopPropagation()"></span>
+                            ng-click="!$root.expertOrLO || parent.vm.markResourceInMaintenance(resource); $event.stopPropagation()"></span>
                         <span class="icon-button fa" md-ink-ripple ng-disabled="!$root.expertOrLO" title="Mark Resource As Faulty"
                             ng-mousedown="$event.stopPropagation()" ng-class="{'fa-exclamation-circle': !resource.faulty, 'fa-warning error-text opaque': resource.faulty}"
-                            ng-click="parent.vm.markResourceFaulty(resource); $event.stopPropagation()"></span>
+                            ng-click="!$root.expertOrLO || parent.vm.markResourceFaulty(resource); $event.stopPropagation()"></span>
                     </div>
                 </div>
             </div>

--- a/app/scheduler/subarrays-draft-assignment/subarrays-draft-assignment.html
+++ b/app/scheduler/subarrays-draft-assignment/subarrays-draft-assignment.html
@@ -91,9 +91,9 @@
                         </div>
 
                         <span class="icon-button fa fa-chevron-circle-down" md-ink-ripple ng-disabled="!parent.vm.iAmAtLeastCA()"
-                            title="Schedule" ng-click="parent.vm.iAmAtLeastCA() && vm.scheduleDraft(item)"></span>
+                            title="Schedule" ng-click="!parent.vm.iAmAtLeastCA() || vm.scheduleDraft(item)"></span>
                         <span class="icon-button fa fa-chevron-right" md-ink-ripple ng-disabled="!parent.vm.iAmAtLeastCA()" title="Unassign Schedule Blocks"
-                            ng-click="parent.vm.iAmAtLeastCA() && vm.freeScheduleBlock(item)"></span>
+                            ng-click="!parent.vm.iAmAtLeastCA() || vm.freeScheduleBlock(item)"></span>
                         <md-menu>
                             <span class="icon-button fa fa-ellipsis-v" md-ink-ripple style="padding: 6px" ng-click="$mdMenu.open($event); $event.stopPropagation()"></span>
                             <md-menu-content>
@@ -165,7 +165,7 @@
                 ng-mouseover="vm.dragSelect && !vm.dragSelectUnselect? vm.toggleSBSelect(item, true) : vm.dragSelect && vm.dragSelectUnselect? vm.toggleSBSelect(item, false) : ''"
                 style="cursor: pointer" ng-disabled="!$root.expertOrLO">
                 <span class="icon-button fa fa-chevron-left" md-ink-ripple style="width: 22px; padding: 6px 4px" ng-disabled="!parent.vm.iAmAtLeastCA()"
-                    title="Assign schedule block to subarray" ng-click="parent.vm.iAmAtLeastCA() && vm.assignScheduleBlock(item)"
+                    title="Assign schedule block to subarray" ng-click="!parent.vm.iAmAtLeastCA() || vm.assignScheduleBlock(item)"
                     ng-mousedown="$event.stopPropagation()"></span>
                 <div layout="column" layout-align="center start" style="min-width: 100px; max-width: 100px">
                     <span ng-click="$root.showSBDetails(item, $event); $event.stopPropagation()" ng-class="{'manual-color': item.type === 'MANUAL', 'maintenance-color': item.type === 'MAINTENANCE', 'observation-color': item.type === 'OBSERVATION'}"
@@ -180,7 +180,7 @@
                     <span>{{item.desired_start_time}}</span>
                 </div>
                 <span class="icon-button fa fa-remove fixed-width-18" md-ink-ripple style="padding: 6px 2px" ng-disabled="!parent.vm.iAmAtLeastCA()"
-                    ng-mousedown="$event.stopPropagation()" title="Delete Schedule Block" ng-click="parent.vm.iAmAtLeastCA() && vm.removeDraft(item); $event.stopPropagation()"></span>
+                    ng-mousedown="$event.stopPropagation()" title="Delete Schedule Block" ng-click="!parent.vm.iAmAtLeastCA() || vm.removeDraft(item); $event.stopPropagation()"></span>
             </div>
         </md-virtual-repeat-container>
     </div>

--- a/app/services/obs-sched-service.js
+++ b/app/services/obs-sched-service.js
@@ -486,18 +486,21 @@
                 api.guiUrlsRaw = result.data;
                 api.guiUrlsRaw.forEach(function (guiUrls) {
                     var resourceName = guiUrls.name.split('.')[0];
-                    guiUrls.value = JSON.parse(guiUrls.value);
-                    if (!api.guiUrls[resourceName]) {
-                        api.guiUrls[resourceName] = guiUrls;
-                    } else {
-                        guiUrls.value.forEach(function (guiUrl) {
-                            var existingUrlIndex = _.findIndex(api.guiUrls[resourceName].value, {title: guiUrl.title});
-                            if (existingUrlIndex > -1) {
-                                api.guiUrls[resourceName].value[existingUrlIndex] = guiUrl;
-                            } else {
-                                api.guiUrls[resourceName].value.push(guiUrl);
-                            }
-                        });
+                    if (guiUrls.value.length > 0) {
+                        // can't JSON parse empty strings
+                        guiUrls.value = JSON.parse(guiUrls.value);
+                        if (!api.guiUrls[resourceName]) {
+                            api.guiUrls[resourceName] = guiUrls;
+                        } else {
+                            guiUrls.value.forEach(function (guiUrl) {
+                                var existingUrlIndex = _.findIndex(api.guiUrls[resourceName].value, {title: guiUrl.title});
+                                if (existingUrlIndex > -1) {
+                                    api.guiUrls[resourceName].value[existingUrlIndex] = guiUrl;
+                                } else {
+                                    api.guiUrls[resourceName].value.push(guiUrl);
+                                }
+                            });
+                        }
                     }
                 });
             }, function(error) {


### PR DESCRIPTION
This change is necessary because a while back I changed some of the inline <md-button> elements to be <span>'s. ng-disabled only works with input type elements, so we have do some more work when disabling a span (i.e. prevent the click event to propagate).

Also: 
* Allow a CA to mark a resource as faulty when he is the CA of that subarray
* do not try to JSON.parse an empty guiUrl value (throws an exception)
