### PR TITLE
Added subarray in maintenance section to the utilisation report when exporting as a pdf

### DIFF
--- a/app/reports/utilisation-report.js
+++ b/app/reports/utilisation-report.js
@@ -112,6 +112,24 @@
                     theme: 'striped',
                     margin: {top: 8, bottom: 8}});
 
+                rows = [{
+                    value: 'In Maintenance',
+                    percentageOfTotal_1: vm.subarrayMaintenanceDurations['1'].percentageOfTotal || '',
+                    percentageOfTotal_2: vm.subarrayMaintenanceDurations['2'].percentageOfTotal || '',
+                    percentageOfTotal_3: vm.subarrayMaintenanceDurations['3'].percentageOfTotal || '',
+                    percentageOfTotal_4: vm.subarrayMaintenanceDurations['4'].percentageOfTotal || ''
+                }];
+                schedColumns[0].title = "";
+
+                pdf.setFontSize(20);
+                pdf.text('Subarray In Maintenance', 20, pdf.autoTableEndPosY() + 45);
+                pdf.setFontSize(12);
+
+                pdf.autoTable(schedColumns, rows, {
+                    startY: pdf.autoTableEndPosY() + 60,
+                    theme: 'striped',
+                    margin: {top: 8, bottom: 8}});
+
                 var subarrayStateKeys = Object.keys(vm.subarrayStateDurations);
                 rows = [];
                 schedColumns[0].title = "";

--- a/app/reports/utilisation-report.js
+++ b/app/reports/utilisation-report.js
@@ -291,8 +291,8 @@
                         endTime: vm.endDatetimeReadable,
                         filter: vm.searchInputText},
                         { notify: false, reload: false });
-                var startDate = moment(vm.startDatetimeReadable).unix();
-                var endDate =  moment(vm.endDatetimeReadable).unix();
+                var startDate = moment.utc(vm.startDatetimeReadable).unix();
+                var endDate =  moment.utc(vm.endDatetimeReadable).unix();
                 vm.reportTimeWindowSecondsDuration = Math.abs(endDate - startDate);
                 vm.reportTimeWindowSecondsDurationReadable = vm.durationToString(moment.duration(vm.reportTimeWindowSecondsDuration, 's'));
                 vm.createSubarraysReport(startDate, endDate);


### PR DESCRIPTION
This section was overlooked when the report was developed.

<img width="1144" alt="screen shot 2017-03-15 at 7 20 41 pm" src="https://cloud.githubusercontent.com/assets/8371143/23961800/bbf0f32c-09b4-11e7-96ed-73600dbbe815.png">
