### PR TITLE
Enable health views from config

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -95,6 +95,8 @@
             read_only: 'Monitor Only'
         };
 
+        $rootScope.configHealthViews = [];
+
         SessionService.recoverLogin();
 
         $rootScope.getSystemConfig = function (forceConfig) {
@@ -203,6 +205,17 @@
             if (!ConfigService.systemConfig) {
                 $rootScope.getSystemConfig();
             }
+
+            ConfigService.getConfigHealthViews().then(
+                function(result) {
+                    $rootScope.configHealthViews = [];
+                    _.each(result.data, function (value, key, obj) {
+                        $rootScope.configHealthViews.push(key);
+                    });
+                },
+                function(error) {
+                    $log.error(error);
+                });
         };
 
         vm.unbindLoginSuccess = $rootScope.$on('loginSuccess', function () {
@@ -265,8 +278,8 @@
         $rootScope.stateGo = function (newState, params) {
             $state.go(newState, params);
         };
-        vm.sideNavStateGo = function (newState) {
-            $rootScope.stateGo(newState);
+        vm.sideNavStateGo = function (newState, params) {
+            $rootScope.stateGo(newState, params);
             $mdSidenav('left-sidenav').close();
         };
         vm.sideNavRightStateGo = function (newState) {

--- a/app/app.js
+++ b/app/app.js
@@ -458,9 +458,12 @@
             title: 'Receptor Health'
         });
         $stateProvider.state('config-health', {
-            url: '/config-health',
+            url: '/config-health/{configItem}',
             templateUrl: 'app/health/config-health-view/config-health-view.html',
-            title: 'Config Health'
+            title: 'Config Health',
+            params: {
+                configItem: { value: null, squash: true }
+            },
         });
         $stateProvider.state('subarrayHealth', {
             url: '/subarray-health',

--- a/app/app.js
+++ b/app/app.js
@@ -457,6 +457,11 @@
             templateUrl: 'app/health/receptor-health/receptor-health.html',
             title: 'Receptor Health'
         });
+        $stateProvider.state('config-health', {
+            url: '/config-health',
+            templateUrl: 'app/health/config-health-view/config-health-view.html',
+            title: 'Config Health'
+        });
         $stateProvider.state('subarrayHealth', {
             url: '/subarray-health',
             templateUrl: 'app/health/subarray-health/subarray-health.html',

--- a/app/d3/receptor-health-icicle-map.js
+++ b/app/d3/receptor-health-icicle-map.js
@@ -4,7 +4,8 @@ angular.module('katGui.d3')
         return {
             restrict: 'E',
             scope: {
-                dataMapName: '=receptor'
+                dataMapName: '=receptor',
+                sizeStorageKey: '@'
             },
             link: function (scope, element) {
 
@@ -13,6 +14,7 @@ angular.module('katGui.d3')
                 var margin = {top: 8, right: 8, left: 8, bottom: 8};
                 var tooltip = d3.select(angular.element(document.querySelector('.treemap-tooltip'))[0]);
                 var containerSvg, svg;
+                scope.sizeStorageKey = scope.sizeStorageKey? scope.sizeStorageKey : 'receptorHealthDisplaySize';
                 //create our maplayout for the data and sort it alphabetically
                 //the bockvalue is the relative size of each child element, it is
                 //set to a static 100 when we get our monitor data in the StatusService
@@ -24,11 +26,27 @@ angular.module('katGui.d3')
                         return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
                     });
 
-                if ($localStorage['receptorHealthDisplaySize']) {
-                    scope.chartSize = JSON.parse($localStorage['receptorHealthDisplaySize']);
+                if ($localStorage[scope.sizeStorageKey]) {
+                    scope.chartSize = JSON.parse($localStorage[scope.sizeStorageKey]);
                 } else {
                     scope.chartSize = {width: 480, height: 480};
                 }
+
+                scope.data = function () {
+                    if (scope.dataMapName instanceof Object) {
+                        return scope.dataMapName;
+                    } else {
+                        return StatusService.statusData[scope.dataMapName];
+                    }
+                };
+
+                scope.dataName = function () {
+                    if (scope.dataMapName instanceof Object) {
+                        return scope.dataMapName.name;
+                    } else {
+                        return scope.dataMapName;
+                    }
+                };
 
                 var unbindRedraw = $rootScope.$on('redrawChartMessage', function (event, message) {
                     if (message.size.width) {
@@ -46,9 +64,13 @@ angular.module('katGui.d3')
                 });
 
                 scope.redraw = function () {
+                    if (!scope.data()) {
+                        return;
+                    }
+
                     var width = scope.chartSize.width;
                     var height = scope.chartSize.height;
-                    node = root = data;
+                    node = root = scope.data();
 
                     //create our x,y axis linear scales
                     var x = d3.scale.linear().range([0, width]);
@@ -81,19 +103,24 @@ angular.module('katGui.d3')
                         .attr("height", function (d) {
                             return y(d.dy);
                         })
-                        .attr("id", function (d) {
-                            return d3Util.createSensorId(d, scope.dataMapName);
-                        })
                         //style each element according to its status
                         .attr("class", function (d) {
                             var prefix = d.prefix? d.prefix : '';
-                            var classStr = d3Util.createSensorId(d, scope.dataMapName) + ' health-full-item ';
-                            classStr += (StatusService.sensorValues[prefix + scope.dataMapName + '_' + d.sensor] ?
-                                StatusService.sensorValues[prefix + scope.dataMapName + '_' + d.sensor].status : 'inactive') + '-child child';
+                            var classStr = '';
+                            var dataName = '';
+                            if (scope.dataMapName instanceof Object) {
+                                classStr = d.sensor + ' health-full-item ';
+                                dataName = d.sensor;
+                            } else {
+                                classStr = d3Util.createSensorId(d, scope.dataName()) + ' health-full-item ';
+                                dataName = prefix + scope.dataName() + '_' + d.sensor;
+                            }
+                            classStr += (StatusService.sensorValues[dataName] ?
+                                    StatusService.sensorValues[dataName].status : 'inactive') + '-child child';
                             return classStr;
                         })
                         .call(function (d) {
-                            d3Util.applyTooltipValues(d, tooltip, scope.dataMapName);
+                            d3Util.applyTooltipValues(d, tooltip);
                         })
                         .on("click", icicleClicked);
 
@@ -116,13 +143,18 @@ angular.module('katGui.d3')
                         })
                         .attr("class", function (d) {
                             var prefix = d.prefix? d.prefix : '';
-                            var classStr = d3Util.createSensorId(d, scope.dataMapName) + ' ';
-                            classStr += (StatusService.sensorValues[prefix + scope.dataMapName + '_' + d.sensor] ?
-                                StatusService.sensorValues[prefix + scope.dataMapName + '_' + d.sensor].status : 'inactive');
-                            if (d.depth === 0) {
-                                return classStr + '-child-text parent';
+                            var dataName = '';
+                            if (scope.dataMapName instanceof Object) {
+                                dataName = d.sensor;
                             } else {
-                                return classStr + '-child-text child';
+                                dataName = prefix + scope.dataName() + '_' + d.sensor;
+                            }
+                            var classString = StatusService.sensorValues[dataName] ?
+                                StatusService.sensorValues[dataName].status : 'inactive';
+                            if (d.depth === 0) {
+                                return classString + '-child-text parent ' + dataName;
+                            } else {
+                                return classString + '-child-text child ' + dataName;
                             }
                         })
                         .attr("text-anchor", "middle")

--- a/app/d3/receptor-health-sunburst-map.js
+++ b/app/d3/receptor-health-sunburst-map.js
@@ -4,7 +4,8 @@ angular.module('katGui.d3')
         return {
             restrict: 'E',
             scope: {
-                dataMapName: '=receptor'
+                dataMapName: '=receptor',
+                sizeStorageKey: '@'
             },
             link: function (scope, element) {
 
@@ -20,10 +21,10 @@ angular.module('katGui.d3')
                     .sort(function (a, b) {
                         return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
                     });
+                scope.sizeStorageKey = scope.sizeStorageKey? scope.sizeStorageKey : 'receptorHealthDisplaySize';
 
-
-                if ($localStorage['receptorHealthDisplaySize']) {
-                    scope.chartSize = JSON.parse($localStorage['receptorHealthDisplaySize']);
+                if ($localStorage[scope.sizeStorageKey]) {
+                    scope.chartSize = JSON.parse($localStorage[scope.sizeStorageKey]);
                 } else {
                     scope.chartSize = {width: 480, height: 480};
                 }
@@ -110,13 +111,16 @@ angular.module('katGui.d3')
                         .attr("class", function (d) {
                             var prefix = d.prefix? d.prefix : '';
                             var classStr = '';
+                            var dataName = '';
                             if (scope.dataMapName instanceof Object) {
                                 classStr = d.sensor + ' health-full-item ';
+                                dataName = d.sensor;
                             } else {
                                 classStr = d3Util.createSensorId(d, scope.dataName()) + ' health-full-item ';
+                                dataName = prefix + scope.dataName() + '_' + d.sensor;
                             }
-                            classStr += (StatusService.sensorValues[prefix + scope.dataName() + '_' + d.sensor] ?
-                                    StatusService.sensorValues[prefix + scope.dataName() + '_' + d.sensor].status : 'inactive') + '-child child';
+                            classStr += (StatusService.sensorValues[dataName] ?
+                                    StatusService.sensorValues[dataName].status : 'inactive') + '-child child';
                             return classStr;
                         })
                         .call(function (d) {
@@ -140,12 +144,18 @@ angular.module('katGui.d3')
                         .attr("dy", ".35em") // vertical-align
                         .attr("class", function (d) {
                             var prefix = d.prefix? d.prefix : '';
-                            var classString = StatusService.sensorValues[prefix + scope.dataName() + '_' + d.sensor] ?
-                                StatusService.sensorValues[prefix + scope.dataName() + '_' + d.sensor].status : 'inactive';
-                            if (d.depth === 0) {
-                                return classString + '-child-text parent';
+                            var dataName = '';
+                            if (scope.dataMapName instanceof Object) {
+                                dataName = d.sensor;
                             } else {
-                                return classString + '-child-text child';
+                                dataName = prefix + scope.dataName() + '_' + d.sensor;
+                            }
+                            var classString = StatusService.sensorValues[dataName] ?
+                                StatusService.sensorValues[dataName].status : 'inactive';
+                            if (d.depth === 0) {
+                                return classString + '-child-text parent ' + dataName;
+                            } else {
+                                return classString + '-child-text child ' + dataName;
                             }
                         })
                         .text(function (d) {

--- a/app/d3/receptor-health-sunburst-map.js
+++ b/app/d3/receptor-health-sunburst-map.js
@@ -75,7 +75,6 @@ angular.module('katGui.d3')
                     var x = d3.scale.linear().range([0, 2 * Math.PI]);
                     var y = d3.scale.linear().range([0, radius]);
 
-
                     //create the main svg element
                     containerSvg = d3.select(element[0]).append("svg")
                         .attr("class", "health-chart treemapHealthChart" + scope.dataName())
@@ -124,7 +123,7 @@ angular.module('katGui.d3')
                             return classStr;
                         })
                         .call(function (d) {
-                            d3Util.applyTooltipValues(d, tooltip, scope.dataName());
+                            d3Util.applyTooltipValues(d, tooltip);
                         })
                         .on("click", click);
 

--- a/app/health/config-health-view/config-health-view.html
+++ b/app/health/config-health-view/config-health-view.html
@@ -63,7 +63,6 @@
         </md-menu>
 
     </div>
-    <div>{{vm.selectedConfigView}}</div>
     <div ng-repeat="item in vm.configHealhViews[vm.selectedConfigView] track by $index" ng-switch="vm.mapType" style="display: inline-block">
         <receptor-health-tree-map class="treemap-container" receptor="item" ng-switch-when="Treemap"></receptor-health-tree-map>
         <receptor-health-pack-map class="treemap-container" receptor="item" ng-switch-when="Pack"></receptor-health-pack-map>

--- a/app/health/config-health-view/config-health-view.html
+++ b/app/health/config-health-view/config-health-view.html
@@ -1,0 +1,78 @@
+<div flex style="min-width: 600px; min-height: 600px" ng-controller="ConfigHealthViewCtrl as vm">
+    <div class="legend-popup" style="background: transparent; pointer-events: none;" layout="row" ng-init="transparentLegend = true"
+        ng-class="{'transparent-legend':transparentLegend && !showLegend}">
+        <md-button flex style="pointer-events: auto;" md-theme="{{themePrimaryButtons}}" ng-init="showLegend = false"
+            ng-click="showLegend = !showLegend" ng-mouseenter="transparentLegend = false" ng-mouseleave="transparentLegend = true"
+            class="md-primary md-raised md-icon-button">
+            <span md-theme="white" class="fa fa-eye" ng-show="showLegend" title="Show Legend"></span>
+            <span md-theme="white" class="fa fa-eye-slash" ng-show="!showLegend" title="Hide Legend"></span>
+            </md-button>
+            <div class="md-whiteframe-z3" layout="column" ng-show="showLegend" style="background: white; padding: 8px;">
+                <div layout="row" layout-align="start center">
+                    <div class="color-patch unknown-child" title="Grey"></div><span>Unknown</span></div>
+                <div layout="row" layout-align="start center">
+                    <div class="color-patch nominal-child" title="Green"></div><span>Nominal</span></div>
+                <div layout="row" layout-align="start center">
+                    <div class="color-patch warn-child" title="Amber"></div><span>Warn</span></div>
+                <div layout="row" layout-align="start center">
+                    <div class="color-patch error-child" title="Red"></div><span>Error</span></div>
+                <div layout="row" layout-align="start center">
+                    <div class="color-patch failure-child" title="Blue"></div><span>Failure</span></div>
+                <div layout="row" layout-align="start center">
+                    <div class="color-patch unreachable-child" title="Pink"></div><span>Unreachable</span></div>
+                <div layout="row" layout-align="start center">
+                    <div class="color-patch inactive-child" title="Black"></div><span>CAM Sensor Error</span></div>
+            </div>
+</div>
+<div style="padding-left:16px; padding-right:16px; padding-top:8px;">
+    <div md-theme="{{themePrimaryButtons}}" layout="row" layout-align="start center" style="position: absolute; right: 0; top: 0">
+        <md-menu style="padding: 0">
+            <md-button class="md-icon-button" ng-click="$root.openMenu($mdOpenMenu, $event, 'health-menu-content')">
+                <md-icon class="fa" md-font-icon="fa-ellipsis-v"></md-icon>
+            </md-button>
+            <md-menu-content width="4" style="padding-left: 16px; padding-right: 16px; height: 180px" id="health-menu-content"
+                md-menu-disable-close>
+                <md-menu-item>
+                    <md-select ng-model="vm.mapType" style="margin: 0; padding: 0" ng-click="$event.stopPropagation()" class="md-primary"
+                        md-theme="{{themePrimaryButtons}}" ng-change="vm.mapTypeChanged()">
+                        <md-option ng-value="type" ng-repeat="type in vm.mapTypes">{{type}}</md-option>
+                        </md-select>
+                </md-menu-item>
+                <md-menu-item>
+                    <div layout="row" layout-align="start center" ng-click="$event.stopPropagation()" style="margin:0; padding: 0">
+                        <label style="width: 82px; font-weight: normal; margin-top: 4px;">Chart Width:</label>
+                        <md-input-container md-no-float style="margin-left: 8px;text-align: start; padding: 0; height: 30px"
+                            class="md-primary" title="Set the desired Chart Width for each Tree View">
+                            <input flex placeholder="Minimum" ng-model="vm.treeChartSize.width" ng-change="vm.chartSizeChanged()"
+                                type="number" ng-model-options="{ debounce: 300 }">
+                                </md-input-container>
+                    </div>
+                </md-menu-item>
+                <md-menu-item>
+                    <div layout="row" layout-align="start center" ng-click="$event.stopPropagation()" style="margin:0; padding: 0">
+                        <label style="width: 82px; font-weight: normal; margin-top: 4px;">Chart Height:</label>
+                        <md-input-container md-no-float style="margin-left: 8px;text-align: start; padding: 0; height: 30px"
+                            class="md-primary" title="Set the desired Chart Height for each Tree View">
+                            <input flex placeholder="Minimum" ng-model="vm.treeChartSize.height" ng-change="vm.chartSizeChanged()"
+                                type="number" ng-model-options="{ debounce: 300 }">
+                                </md-input-container>
+                    </div>
+                </md-menu-item>
+
+                </md-menu-content>
+        </md-menu>
+
+    </div>
+    <div>{{vm.selectedConfigView}}</div>
+    <div ng-repeat="item in vm.configHealhViews[vm.selectedConfigView] track by $index" ng-switch="vm.mapType" style="display: inline-block">
+        <receptor-health-tree-map class="treemap-container" receptor="item" ng-switch-when="Treemap"></receptor-health-tree-map>
+        <receptor-health-pack-map class="treemap-container" receptor="item" ng-switch-when="Pack"></receptor-health-pack-map>
+        <receptor-health-partition-map class="treemap-container" receptor="item" ng-switch-when="Partition"></receptor-health-partition-map>
+        <receptor-health-icicle-map class="treemap-container" receptor="item" ng-switch-when="Icicle"></receptor-health-icicle-map>
+        <receptor-health-sunburst-map class="treemap-container" receptor="item" ng-switch-when="Sunburst"></receptor-health-sunburst-map>
+        <receptor-health-force class="treemap-container" receptor="item" ng-switch-when="Force Layout"></receptor-health-force>
+    </div>
+
+</div>
+<div class="treemap-tooltip" style="visibility: hidden; background-color: #ffffff"></div>
+</div>

--- a/app/health/config-health-view/config-health-view.html
+++ b/app/health/config-health-view/config-health-view.html
@@ -64,12 +64,10 @@
 
     </div>
     <div ng-repeat="item in vm.configHealhViews[vm.selectedConfigView] track by $index" ng-switch="vm.mapType" style="display: inline-block">
-        <receptor-health-tree-map class="treemap-container" size-storage-key="configHealthDisplaySize" receptor="item" ng-switch-when="Treemap"></receptor-health-tree-map>
         <receptor-health-pack-map class="treemap-container" size-storage-key="configHealthDisplaySize" receptor="item" ng-switch-when="Pack"></receptor-health-pack-map>
         <receptor-health-partition-map class="treemap-container" size-storage-key="configHealthDisplaySize" receptor="item" ng-switch-when="Partition"></receptor-health-partition-map>
         <receptor-health-icicle-map class="treemap-container" size-storage-key="configHealthDisplaySize" receptor="item" ng-switch-when="Icicle"></receptor-health-icicle-map>
         <receptor-health-sunburst-map class="treemap-container" size-storage-key="configHealthDisplaySize" receptor="item" ng-switch-when="Sunburst"></receptor-health-sunburst-map>
-        <receptor-health-force class="treemap-container" size-storage-key="configHealthDisplaySize" receptor="item" ng-switch-when="Force Layout"></receptor-health-force>
     </div>
 
 </div>

--- a/app/health/config-health-view/config-health-view.html
+++ b/app/health/config-health-view/config-health-view.html
@@ -64,12 +64,12 @@
 
     </div>
     <div ng-repeat="item in vm.configHealhViews[vm.selectedConfigView] track by $index" ng-switch="vm.mapType" style="display: inline-block">
-        <receptor-health-tree-map class="treemap-container" receptor="item" ng-switch-when="Treemap"></receptor-health-tree-map>
-        <receptor-health-pack-map class="treemap-container" receptor="item" ng-switch-when="Pack"></receptor-health-pack-map>
-        <receptor-health-partition-map class="treemap-container" receptor="item" ng-switch-when="Partition"></receptor-health-partition-map>
-        <receptor-health-icicle-map class="treemap-container" receptor="item" ng-switch-when="Icicle"></receptor-health-icicle-map>
-        <receptor-health-sunburst-map class="treemap-container" receptor="item" ng-switch-when="Sunburst"></receptor-health-sunburst-map>
-        <receptor-health-force class="treemap-container" receptor="item" ng-switch-when="Force Layout"></receptor-health-force>
+        <receptor-health-tree-map class="treemap-container" size-storage-key="configHealthDisplaySize" receptor="item" ng-switch-when="Treemap"></receptor-health-tree-map>
+        <receptor-health-pack-map class="treemap-container" size-storage-key="configHealthDisplaySize" receptor="item" ng-switch-when="Pack"></receptor-health-pack-map>
+        <receptor-health-partition-map class="treemap-container" size-storage-key="configHealthDisplaySize" receptor="item" ng-switch-when="Partition"></receptor-health-partition-map>
+        <receptor-health-icicle-map class="treemap-container" size-storage-key="configHealthDisplaySize" receptor="item" ng-switch-when="Icicle"></receptor-health-icicle-map>
+        <receptor-health-sunburst-map class="treemap-container" size-storage-key="configHealthDisplaySize" receptor="item" ng-switch-when="Sunburst"></receptor-health-sunburst-map>
+        <receptor-health-force class="treemap-container" size-storage-key="configHealthDisplaySize" receptor="item" ng-switch-when="Force Layout"></receptor-health-force>
     </div>
 
 </div>

--- a/app/health/config-health-view/config-health-view.js
+++ b/app/health/config-health-view/config-health-view.js
@@ -3,14 +3,16 @@
     angular.module('katGui.health')
         .controller('ConfigHealthViewCtrl', ConfigHealthViewCtrl);
 
-    function ConfigHealthViewCtrl($log, $interval, $rootScope, $scope, $localStorage, SensorsService, ConfigService, StatusService, NotifyService) {
+    function ConfigHealthViewCtrl($log, $interval, $rootScope, $scope, $localStorage, SensorsService,
+                                  ConfigService, StatusService, NotifyService, $stateParams) {
 
         var vm = this;
 
         vm.mapTypes = ['Treemap', 'Pack', 'Partition', 'Icicle', 'Sunburst', 'Force Layout'];
         vm.connectInterval = null;
         vm.configHealhViews = {};
-        vm.selectedConfigView = '';
+        vm.configItemsSelect = [];
+        vm.selectedConfigView = $stateParams.configItem ? $stateParams.configItem : '';
 
         if ($localStorage['configHealthDisplayMapType']) {
             vm.mapType = $localStorage['configHealthDisplayMapType'];
@@ -53,8 +55,10 @@
 
         ConfigService.getConfigHealthViews().then(
             function(result) {
+                vm.configItemsSelect = [];
                 vm.configHealhViews = result.data;
-                _.each(vm.configHealhViews, function (value, key, obj) {
+                _.each(result.data, function (value, key, obj) {
+                    vm.configItemsSelect.push(key);
                     if (value instanceof Array) {
                         value.forEach(function (item) {
                             vm.populateSensorNames(key, item);
@@ -63,8 +67,6 @@
                         vm.populateSensorNames(key, value);
                     }
                 });
-                // TODO populate this from the url
-                vm.selectedConfigView = Object.keys(vm.configHealhViews)[1];
                 vm.redrawCharts();
                 vm.connectListeners();
             },

--- a/app/health/config-health-view/config-health-view.js
+++ b/app/health/config-health-view/config-health-view.js
@@ -8,7 +8,7 @@
 
         var vm = this;
 
-        vm.mapTypes = ['Treemap', 'Pack', 'Partition', 'Icicle', 'Sunburst', 'Force Layout'];
+        vm.mapTypes = ['Pack', 'Partition', 'Icicle', 'Sunburst'];
         vm.connectInterval = null;
         vm.configHealhViews = {};
         vm.configItemsSelect = [];

--- a/app/health/config-health-view/config-health-view.js
+++ b/app/health/config-health-view/config-health-view.js
@@ -1,0 +1,134 @@
+(function() {
+
+    angular.module('katGui.health')
+        .controller('ConfigHealthViewCtrl', ConfigHealthViewCtrl);
+
+    function ConfigHealthViewCtrl($log, $interval, $rootScope, $scope, $localStorage, SensorsService, ConfigService, StatusService, NotifyService) {
+
+        var vm = this;
+
+        vm.mapTypes = ['Treemap', 'Pack', 'Partition', 'Icicle', 'Sunburst', 'Force Layout'];
+        vm.connectInterval = null;
+        vm.configHealhViews = {};
+        vm.selectedConfigView = '';
+
+        if ($localStorage['configHealthDisplayMapType']) {
+            vm.mapType = $localStorage['configHealthDisplayMapType'];
+        }
+
+        if ($localStorage['configHealthDisplaySize']) {
+            vm.treeChartSize = JSON.parse($localStorage['configHealthDisplaySize']);
+        } else {
+            vm.treeChartSize = {
+                width: 480,
+                height: 480
+            };
+        }
+
+        if (!vm.mapType) {
+            vm.mapType = 'Sunburst';
+        }
+
+        vm.populateSensorNames = function(containerName, parent) {
+            if (!StatusService.configHealthSensors[containerName]) {
+                StatusService.configHealthSensors[containerName] = {};
+            }
+            StatusService.configHealthSensors[containerName][parent.sensor] = 1;
+            if (parent.children && parent.children.length > 0) {
+                parent.children.forEach(function(child) {
+                    vm.populateSensorNames(containerName, child);
+                });
+            }
+        };
+
+        vm.chartSizeChanged = function() {
+            $localStorage['configHealthDisplaySize'] = JSON.stringify(vm.treeChartSize);
+            vm.redrawCharts();
+        };
+
+        vm.mapTypeChanged = function() {
+            $localStorage['configHealthDisplayMapType'] = vm.mapType;
+            vm.redrawCharts();
+        };
+
+        ConfigService.getConfigHealthViews().then(
+            function(result) {
+                vm.configHealhViews = result.data;
+                _.each(vm.configHealhViews, function (value, key, obj) {
+                    if (value instanceof Array) {
+                        value.forEach(function (item) {
+                            vm.populateSensorNames(key, item);
+                        });
+                    } else {
+                        vm.populateSensorNames(key, value);
+                    }
+                });
+                // TODO populate this from the url
+                vm.selectedConfigView = Object.keys(vm.configHealhViews)[1];
+                vm.redrawCharts();
+                vm.connectListeners();
+            },
+            function(error) {
+                $log.error(error);
+                NotifyService.showSimpleDialog("Error retrieving config health views from katconf-webserver, is the service running?");
+            });
+
+        vm.connectListeners = function() {
+            SensorsService.connectListener()
+                .then(function() {
+                    vm.initSensors();
+                    if (vm.connectInterval) {
+                        $interval.cancel(vm.connectInterval);
+                        vm.connectInterval = null;
+                        NotifyService.showSimpleToast('Reconnected :)');
+                    }
+                }, function() {
+                    $log.error('Could not establish sensor connection. Retrying every 10 seconds.');
+                    if (!vm.connectInterval) {
+                        vm.connectInterval = $interval(vm.connectListeners, 10000);
+                    }
+                });
+            vm.handleSocketTimeout();
+        };
+
+        vm.handleSocketTimeout = function() {
+            SensorsService.getTimeoutPromise()
+                .then(function() {
+                    NotifyService.showSimpleToast('Connection timeout! Attempting to reconnect...');
+                    if (!vm.connectInterval) {
+                        vm.connectInterval = $interval(vm.connectListeners, 10000);
+                        vm.connectListeners();
+                    }
+                });
+        };
+
+        vm.initSensors = function() {
+            if (vm.selectedConfigView) {
+                SensorsService.setSensorStrategies(Object.keys(StatusService.configHealthSensors[vm.selectedConfigView]).join('|'), 'event-rate', 1, 360);
+            }
+        };
+
+        vm.redrawCharts = function () {
+            //TODO implement this plox
+        };
+
+        vm.pendingUpdatesInterval = $interval(StatusService.applyPendingUpdates, 300);
+
+        var unbindUpdate = $rootScope.$on('sensorsServerUpdateMessage', function(event, sensor) {
+            var sensorName = sensor.name.split(':')[1];
+            sensor.status = sensor.value.status;
+            sensor.received_timestamp = sensor.value.received_timestamp;
+            sensor.timestamp = sensor.value.timestamp;
+            sensor.value = sensor.value.value;
+            StatusService.sensorValues[sensorName] = sensor;
+            StatusService.addToUpdateQueue(sensorName);
+        });
+
+        $scope.$on('$destroy', function() {
+            // $interval.cancel(vm.pendingUpdatesInterval);
+            unbindUpdate();
+            SensorsService.disconnectListener();
+            StatusService.sensorValues = {};
+        });
+    }
+})();

--- a/app/health/config-health-view/config-health-view.js
+++ b/app/health/config-health-view/config-health-view.js
@@ -67,6 +67,7 @@
                         vm.populateSensorNames(key, value);
                     }
                 });
+                $rootScope.configHealthViews = vm.configItemsSelect;
                 vm.redrawCharts();
                 vm.connectListeners();
             },

--- a/app/health/config-health-view/config-health-view.js
+++ b/app/health/config-health-view/config-health-view.js
@@ -111,7 +111,7 @@
         };
 
         vm.redrawCharts = function () {
-            //TODO implement this plox
+            $rootScope.$emit('redrawChartMessage', {size: vm.treeChartSize});
         };
 
         vm.pendingUpdatesInterval = $interval(StatusService.applyPendingUpdates, 300);

--- a/app/services/config-service.js
+++ b/app/services/config-service.js
@@ -78,6 +78,10 @@
             return deferred.promise;
         };
 
+        api.getConfigHealthViews = function () {
+            return $http(createRequest('get', urlBase() + '/statustrees/custom_views'));
+        };
+
         api.getProductConfig = function () {
             var deferred = $q.defer();
             if (api.productConfig) {

--- a/app/services/status-service.js
+++ b/app/services/status-service.js
@@ -16,6 +16,7 @@
         api.controlledResources = [];
         api.topStatusTreesSensors = {};
         api.receptorTreesSensors = {};
+        api.configHealthSensors = {};
         api.updateQueue = [];
 
         api.addToUpdateQueue = function (sensor) {

--- a/app/services/status-service.js
+++ b/app/services/status-service.js
@@ -98,6 +98,15 @@
                 d3.selectAll('.health-full-item.' + sensorName).attr('class', function (d) {
                     return api.getClassesOfSensor(d, sensorName, true) + ' health-full-item';
                 });
+                d3.selectAll('text.' + sensorName).attr('class', function (d) {
+                    var classString = api.sensorValues[sensorName] ?
+                        api.sensorValues[sensorName].status : 'inactive';
+                    if (d.depth === 0) {
+                        return classString + '-child-text parent ' + sensorName;
+                    } else {
+                        return classString + '-child-text child ' + sensorName;
+                    }
+                });
                 d3.selectAll('.text-bg-rect.' + sensorName).attr('class', function (d) {
                     return api.getClassesOfSensor(d, sensorName, false) + ' text-bg-rect';
                 });

--- a/index.html
+++ b/index.html
@@ -93,6 +93,7 @@
 <script src="app/health/receptor-status/receptor-status.js"></script>
 <script src="app/health/receptor-pointing/receptor-pointing.js"></script>
 <script src="app/health/custom-health/custom-health.js"></script>
+<script src="app/health/config-health-view/config-health-view.js"></script>
 <script src="app/health/subarray-health/subarray-health.js"></script>
 <script src="app/sensor-graph/sensor-graph.js"></script>
 <script src="app/sensor-list/sensor-list.js"></script>
@@ -147,6 +148,9 @@
                         </div>
                         <div class="menu-item menu-item-indented" layout="row" layout-align="start center" ng-click="vm.sideNavStateGo('receptorStatus')">
                             <md-button flex><span class="fa fa-th"></span><span>Receptor Status</span></md-button>
+                        </div>
+                        <div class="menu-item menu-item-indented" layout="row" layout-align="start center" ng-click="vm.sideNavStateGo('config-health')">
+                            <md-button flex><span class="fa fa-file-code-o"></span><span>Config Health</span></md-button>
                         </div>
                         <div class="menu-item menu-item-indented" layout="row" layout-align="start center" ng-click="vm.sideNavStateGo('receptorPointing')">
                             <md-button flex><span class="fa fa-crosshairs"></span><span>Receptor Pointing</span></md-button>

--- a/index.html
+++ b/index.html
@@ -149,9 +149,6 @@
                         <div class="menu-item menu-item-indented" layout="row" layout-align="start center" ng-click="vm.sideNavStateGo('receptorStatus')">
                             <md-button flex><span class="fa fa-th"></span><span>Receptor Status</span></md-button>
                         </div>
-                        <div class="menu-item menu-item-indented" layout="row" layout-align="start center" ng-click="vm.sideNavStateGo('config-health')">
-                            <md-button flex><span class="fa fa-file-code-o"></span><span>Config Health</span></md-button>
-                        </div>
                         <div class="menu-item menu-item-indented" layout="row" layout-align="start center" ng-click="vm.sideNavStateGo('receptorPointing')">
                             <md-button flex><span class="fa fa-crosshairs"></span><span>Receptor Pointing</span></md-button>
                         </div>
@@ -163,6 +160,13 @@
                         </div>
                         <div class="menu-item" layout="row" layout-align="start center" ng-click="vm.sideNavStateGo('activity')">
                             <md-button flex><span class="fa fa-dashboard"></span><span>System Activity</span></md-button>
+                        </div>
+                    </md-item-content>
+                </md-item>
+                <md-item>
+                    <md-item-content style="margin-top: 8px; margin-bottom: 8px; padding-bottom: 8px; border-bottom: 1px solid #e5e5e5;" layout="column">
+                        <div ng-repeat="configItem in $root.configHealthViews track by $index" class="menu-item" layout="row" layout-align="start center">
+                            <md-button ng-click="vm.sideNavStateGo('config-health', {configItem: configItem})" flex><span class="fa fa-file-code-o"></span><span>{{configItem.toUpperCase()}} Health</span></md-button>
                         </div>
                     </md-item-content>
                 </md-item>


### PR DESCRIPTION
See https://github.com/ska-sa/katcamconfig/pull/189.

The PR above supplies the config needed for building health displays dynamically. In pictures, the config above gives us a dynamic list of health views in the left navigation bar:
<img width="291" alt="screen shot 2017-03-16 at 3 55 46 pm" src="https://cloud.githubusercontent.com/assets/8371143/23999900/648a2a28-0a62-11e7-88fe-16e8b0a45898.png">
Clicking one of those links takes you to:
<img width="869" alt="screen shot 2017-03-16 at 3 55 52 pm" src="https://cloud.githubusercontent.com/assets/8371143/24000081/e9a0e45e-0a62-11e7-92ee-f961956bffe6.png">
The above display will display a list of defined tree views as defined in config, the same way the receptor display shows lists of treeviews.