### PR TITLE
States of resources on subarray activate and misc

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -559,14 +559,14 @@
             parent: schedulerHome,
             url: '/resources/:subarray_id',
             templateUrl: 'app/scheduler/subarray-resources/subarray-resources.html',
-            title: 'Subarrays.Resource Assignment'
+            title: 'Subarrays.Resources'
         };
         var observationsOverview = {
             name: 'scheduler.observations',
             parent: schedulerHome,
             url: '/observations',
             templateUrl: 'app/scheduler/observations/observations-overview.html',
-            title: 'Subarrays.Observations Overview'
+            title: 'Subarrays.Overview'
         };
         var observationsDetail = {
             name: 'scheduler.observations.detail',

--- a/app/scheduler/observations/observations-detail.html
+++ b/app/scheduler/observations/observations-detail.html
@@ -1,4 +1,4 @@
-<div flex layout="row" style="min-width: 1000px; min-height: 650px; padding: 0 8px 8px 8px" ng-controller="SubArrayObservationsDetail as vm">
+<div flex layout="row" style="min-width: 1150px; min-height: 650px; padding: 0 8px 8px 8px" ng-controller="SubArrayObservationsDetail as vm">
     <div flex layout="column">
         <div flex style="min-height: 150px;" layout="column">
             <md-toolbar md-theme="{{vm.subarray.state === 'inactive'? 'grey' : vm.subarray.state === 'active'? 'green' : vm.subarray.state === 'error'? 'amber' : 'deep-purple'}}"
@@ -27,8 +27,8 @@
                 <span flex></span>
 
                 <md-menu style="margin: 0 8px; margin-bottom: 0; padding: 0; position: relative">
-                    <span md-ink-ripple style="margin: 0; padding: 0px" ng-click="$mdMenu.open($event)" class="opaque-hover">
-                        <span class="fa fa-chevron-down subarray-select-chevron" style="top: 7px"></span>
+                    <span md-ink-ripple style="margin: 0; padding: 0px" ng-click="$mdMenu.open($event)">
+                        <span class="fa fa-chevron-down subarray-select-chevron" style="top: 7px; opacity: 1.0"></span>
                         <span style="margin-left: 16px">MODE: <b>{{vm.subarray.mode}}</b></span> </span>
                     </span>
                     <md-menu-content>
@@ -131,8 +131,8 @@
         </md-toolbar>
         <div flex class="schedule-block-resource-window md-whiteframe-z1" style="max-width: 450px; min-height: 284px; overflow: auto; min-width: 150px"
             layout="column" layout-wrap layout-align="start start">
-            <div class="resource-counter-overlay" title="The amount of resources assigned to this subarray">
-                {{vm.subarray.allocations.length}}
+            <div class="resource-counter-overlay" title="The amount of receptors assigned to this subarray">
+                {{parent.vm.getTotalReceptorsInSubarray()}}
             </div>
             <div ng-repeat="resource in vm.subarray.allocations track by $index" ng-class="{'maintenance-bg-hover': resource.maintenance}"
                 class="resource-item" style="max-height: 80px; position: relative; padding-right: 0" layout="row"

--- a/app/scheduler/observations/observations-overview.html
+++ b/app/scheduler/observations/observations-overview.html
@@ -1,4 +1,4 @@
-<div flex layout="column" style="min-width: 1015px; min-height: 1000px; margin: 0 8px 8px 8px" ng-controller="SubArrayExecutorOverview as vm">
+<div flex layout="column" style="min-width: 1150px; min-height: 1000px; margin: 0 8px 8px 8px" ng-controller="SubArrayExecutorOverview as vm">
     <div flex ng-repeat="subarray in vm.subarrays | orderBy:'id'" class="subarray-container md-whiteframe-z2"
         layout="row" flex style="min-height: 120px" md-theme="{{subarray.state === 'inactive'? 'grey' : subarray.state === 'active'? 'green' : subarray.state === 'error'? 'amber' : 'deep-purple'}}">
         <div layout="column" flex>
@@ -13,9 +13,24 @@
                 <span flex></span>
                 <div ng-include="'app/scheduler/templates/sb-scheduled-list-header.html'" class="list-subheader-title"
                     style="height: 32px; width: 100%"></div>
-                <div ng-include="'app/scheduler/templates/subarray-config-container.html'"></div>
-                <md-menu style="margin-top: -16px; margin-bottom: 0; padding: 0; position: relative">
-                    <span md-ink-ripple style="margin: 0; padding: 0" ng-click="$mdMenu.open($event)" class="opaque-hover">
+                <div layout="row" layout-align="center" class="subarray-config-container">
+                    <span md-ink-ripple ng-click="parent.vm.showSubarrayLogs()" class="icon-button fa fa-file-text-o opaque-hover" title="Show Subarray logs"
+                        style="font-size: 18px; height: 22px; padding: 2px 4px"></span>
+                    <span title="Control Authority" style="margin: 0 12px">
+                         <i>CA: </i><b>{{subarray.delegated_ca}}</b>
+                     </span>
+                    <span title="Selected Band" style="margin: 0 12px">
+                         <i>Band: </i><b>{{subarray.band ? subarray.band : 'None'}}</b>
+                     </span>
+                    <span title="Selected Product" style="margin: 0 12px">
+                         <i>Product: </i><b>{{subarray.product ? subarray.product : 'None'}}</b>
+                     </span>
+                    <span ng-show="subarray.config_label" title="Config Label" style="margin: 0 12px">
+                         <i>Config Label: </i><b>{{subarray.config_label ? subarray.config_label : 'None'}}</b>
+                     </span>
+                </div>
+                <md-menu style="margin-top: -16px; margin-bottom: 0; padding: 0; position: relative" class="subarray-mode-button">
+                    <span md-ink-ripple style="margin: 0; padding: 0" ng-click="$mdMenu.open($event)">
                         <span class="fa fa-chevron-down subarray-select-chevron" style="top: 7px"></span>
                         <span style="margin-left: 16px">MODE: <b>{{subarray.mode}}</b></span> </span>
                     </span>

--- a/app/scheduler/scheduler-home.js
+++ b/app/scheduler/scheduler-home.js
@@ -16,7 +16,7 @@
         UserLogService, NotifyService, MonitorService, ConfigService, $stateParams, $q, $mdDialog, UserService) {
 
         var vm = this;
-        var receptorRegex = new RegExp('^(m0..|ant.)$');
+        var receptorRegex = new RegExp('^(m|ant|dsh)\\d{1,4}$');
         vm.childStateShowing = $state.current.name !== 'scheduler';
         vm.subarrays = ObsSchedService.subarrays;
         vm.programBlocks = ObsSchedService.programBlocks;
@@ -828,9 +828,8 @@
                     classes += ' resource-state-activated';
                 } else if (resourceStateSensor.value === 'error') {
                     classes += ' resource-state-error';
-                } else if (resourceStateSensor.value === 'configuring' ||
-                           resourceStateSensor.value === 'configured' ||
-                           resourceStateSensor.value === 'activating') {
+                } else if (['deactivating', 'configuring', 'configured', 'activating']
+                           .indexOf(resourceStateSensor.value) > -1) {
                     classes += ' resource-state-busy';
                 }
             }

--- a/app/scheduler/scheduler-home.js
+++ b/app/scheduler/scheduler-home.js
@@ -16,6 +16,7 @@
         UserLogService, NotifyService, MonitorService, ConfigService, $stateParams, $q, $mdDialog, UserService) {
 
         var vm = this;
+        var receptorRegex = new RegExp('^(m0..|ant.)$');
         vm.childStateShowing = $state.current.name !== 'scheduler';
         vm.subarrays = ObsSchedService.subarrays;
         vm.programBlocks = ObsSchedService.programBlocks;
@@ -29,6 +30,7 @@
         vm.iAmCA = false;
         vm.modeTypes = ['queue', 'manual'];
         vm.guiUrls = ObsSchedService.guiUrls;
+        vm.resourcesStates = ObsSchedService.resourcesStates;
 
         if (!$stateParams.subarray_id) {
             $state.go($state.current.name, {
@@ -107,6 +109,18 @@
                 vm.subarray = null;
             }
         });
+
+        vm.getTotalReceptorsInSubarray = function () {
+            var counter = 0;
+            if (vm.subarray && vm.subarray.allocations) {
+                vm.subarray.allocations.forEach(function (resource) {
+                    if (receptorRegex.test(resource.name)) {
+                        counter++;
+                    }
+                });
+            }
+            return counter;
+        };
 
         vm.currentState = function() {
             return $state.current.name;
@@ -798,6 +812,29 @@
             return function(item) {
                 return angular.isDefined(item.schedule_blocks) && item.schedule_blocks.length > 0;
             };
+        };
+
+        vm.classForResource = function (resource) {
+            var classes = "";
+            if (vm.isResourceInMaintenance(resource)) {
+                classes += 'maintenance-bg-hover';
+            }
+            if (vm.isResourceFaulty(resource)) {
+                classes += ' faulty-border';
+            }
+            var resourceStateSensor = vm.resourcesStates[resource.name];
+            if (resourceStateSensor) {
+                if (resourceStateSensor.value === 'activated') {
+                    classes += ' resource-state-activated';
+                } else if (resourceStateSensor.value === 'error') {
+                    classes += ' resource-state-error';
+                } else if (resourceStateSensor.value === 'configuring' ||
+                           resourceStateSensor.value === 'configured' ||
+                           resourceStateSensor.value === 'activating') {
+                    classes += ' resource-state-busy';
+                }
+            }
+            return classes;
         };
 
         $scope.$on('$destroy', function() {

--- a/app/scheduler/scheduler.less
+++ b/app/scheduler/scheduler.less
@@ -91,6 +91,9 @@
     min-width: 147px;
     border: 1px solid rgba(158, 158, 158, 0.3);
     overflow: hidden;
+    a {
+        margin-right: 4px;
+    }
     &:hover {
         background-color: rgba(158, 158, 158, 0.1);
     }
@@ -619,9 +622,19 @@
 
 .subarray-action-icon {
     font-size: 30px;
-    padding: 6px;
-    margin: 0 6px;
+    padding: 4px;
+    margin: 0 2px;
     border-radius: 50%;
+}
+
+.subarray-mode-button {
+    opacity: 0.5;
+    .subarray-select-chevron {
+        opacity: 1.0;
+    }
+    &:hover {
+        opacity: 1.0;
+    }
 }
 
 .subarray-select-chevron {
@@ -658,10 +671,16 @@
     top: 0;
     left: 0;
     right: 0;
-    font-size: 12px;
+    font-size: 16px;
     md-menu {
-        margin: 0 2px;
+        margin: 0 12px;
         position: relative;
+    }
+    span {
+        opacity: 0.4;
+        &:hover {
+            opacity: 1.0;
+        }
     }
 }
 
@@ -707,4 +726,34 @@
     &:hover {
         opacity: 1.0;
     }
+}
+
+.resource-state-activated {
+    background-color: rgba(76, 175, 80, 0.2);
+    // color: rgba(255, 255, 255, 0.87);
+    &:hover {
+        background-color: rgba(76, 175, 80, 0.25);
+    }
+}
+
+.resource-state-error {
+    background-color: rgba(244, 67, 54, 0.2);
+    &:hover {
+        background-color: rgba(244, 67, 54, 0.25);
+    }
+}
+
+.resource-state-busy {
+    background-color: rgba(171, 71, 187, 0.2);
+    // color: rgba(255, 255, 255, 0.87);
+    &:hover {
+        background-color: rgba(171, 71, 187, 0.25);
+    }
+}
+
+.gui-urls-link-container {
+    max-height: 50px;
+    min-width: 150px;
+    overflow-x: auto;
+    overflow-y: hidden;
 }

--- a/app/scheduler/subarray-resources/subarray-resources.html
+++ b/app/scheduler/subarray-resources/subarray-resources.html
@@ -1,10 +1,10 @@
-<div flex layout="column" style="min-width: 1000px; min-height: 600px" class="unselectable" ng-controller="SubArrayResourcesCtrl as vm"
+<div flex layout="column" style="min-width: 1150px; min-height: 600px" class="unselectable" ng-controller="SubArrayResourcesCtrl as vm"
     ng-mouseup="vm.dragSelect = false">
     <div flex layout="row">
         <div flex layout="column" style="padding: 0 8px">
             <div class="subarray-container" layout="row" style="min-width: 450px; position: relative" flex ng-class="{'maintenance-bg': vm.subarray.maintenance}">
-                <div class="resource-counter-overlay" title="The total of resources assigned to this subarray">
-                    {{vm.subarray.allocations.length}}
+                <div class="resource-counter-overlay" title="The number of receptors assigned to this subarray">
+                    {{parent.vm.getTotalReceptorsInSubarray()}}
                 </div>
                 <div flex class="md-whiteframe-z2" layout="column">
                     <md-toolbar md-theme="{{vm.subarray.state === 'inactive'? 'grey' : vm.subarray.state === 'active'? 'green' : vm.subarray.state === 'error'? 'amber' : 'deep-purple'}}"
@@ -32,8 +32,8 @@
 
                         <span flex></span>
 
-                        <md-menu style="margin: 0 8px; padding: 0; position: relative">
-                            <span md-ink-ripple style="margin: 0; padding: 0px" ng-click="$mdMenu.open($event)" class="opaque-hover">
+                        <md-menu style="margin: 0 8px; padding: 0; position: relative" class="subarray-mode-button">
+                            <span md-ink-ripple style="margin: 0; padding: 0px" ng-click="$mdMenu.open($event)">
                                 <span class="fa fa-chevron-down subarray-select-chevron" style="top: 7px"></span>
                                 <span style="margin-left: 16px">MODE: <b>{{vm.subarray.mode}}</b></span> </span>
                             </span>
@@ -44,13 +44,18 @@
                             </md-menu-content>
                         </md-menu>
 
+                        <span class="fa fa-cubes subarray-action-icon hover-opacity"
+                            title="Load last known subarray configuration - {{vm.lastKnownSubarrayConfig? vm.lastKnownSubarrayConfig : 'Could not find the last known configuration for any subarrays'}}"
+                            md-ink-ripple ng-show="parent.vm.iAmAtLeastCA()"
+                            ng-disabled="!vm.lastKnownSubarrayConfig || vm.subarray.state !== 'inactive'"
+                            ng-click="(!parent.vm.iAmAtLeastCA() && (!vm.lastKnownSubarrayConfig || vm.subarray.state !== 'inactive')) || vm.loadLastKnownSubarrayConfig()"></span>
                         <span class="fa fa-power-off subarray-action-icon hover-opacity" md-ink-ripple ng-show="$root.expertOrLO && vm.subarray.state === 'inactive'"
                             title="Activate Subarray" ng-click="parent.vm.activateSubarray()"></span>
                         <span class="fa fa-recycle subarray-action-icon hover-opacity" md-ink-ripple ng-show="parent.vm.iAmAtLeastCA()"
                             title="Free Subarray" ng-click="parent.vm.freeSubarray()"></span>
 
                         <md-menu ng-show="$root.expertOrLO" md-theme="{{themePrimary}}">
-                            <md-button style="padding: 0; font-size: 24px" class="md-icon-button inline-action-button hover-opacity"
+                            <md-button style="padding: 0; margin: 4px   ; font-size: 24px" class="md-icon-button inline-action-button hover-opacity"
                                 ng-click="vm.initLastKnownConfig(); $mdMenu.open($event)">
                                 <span class="fa fa-ellipsis-v"></span>
                             </md-button>
@@ -113,10 +118,11 @@
                     </md-toolbar>
 
                     <div flex layout="column" layout-wrap style="overflow-y: auto">
-                        <div style="max-height: 80px" flex="25" class="resource-item" layout="row" layout-align="start center"
-                            ng-repeat="resource in vm.subarray.allocations | orderBy:'name'" ng-class="{'maintenance-bg-hover': parent.vm.isResourceInMaintenance(resource), 'faulty-border': parent.vm.isResourceFaulty(resource)}">
-                            <span flex style="font-size: 18px; margin-left: 4px" ng-class="{'error-text':resource.state === 'faulty', 'maintenance-text':resource.maintenance}">{{resource.name}}</span>
-                            <div flex layout="column" layout-wrap style="max-height: 100%; max-width: 200px; min-width: 150px; overflow: auto">
+                        <div style="max-height: 52px; position: relative" flex="25" class="resource-item" layout="row" layout-align="start center"
+                            ng-repeat="resource in vm.subarray.allocations | orderBy:'name'" ng-class="parent.vm.classForResource(resource)">
+                            <span flex style="font-size: 18px; margin-left: 4px; margin-bottom: 12px" class="resource-name-text">{{resource.name}}</span>
+                            <span style="position: absolute; left: 8px; bottom: 4px; font-size: 12px">{{parent.vm.resourcesStates[resource.name].value}}</span>
+                            <div flex layout="column" layout-wrap class="gui-urls-link-container">
                                 <a ng-repeat="link in parent.vm.guiUrls[resource.name].value track by $index" href="{{link.href}}" title="{{link.description}}" style="padding: 0">{{link.title}}</a>
                             </div>
                             <span class="icon-button fa fa-refresh" ng-disabled="!$root.expertOrLO" md-ink-ripple ng-show="resource.maintenance && vm.subarray.maintenance"
@@ -155,7 +161,7 @@
                         ng-model="vm.q" placeholder="Search Resources..." />
                 </md-toolbar>
                 <div flex style="overflow: auto" layout="column" layout-wrap>
-                    <div style="max-height: 80px; position: relative; cursor: pointer" flex="25" class="resource-item" layout="row"
+                    <div style="max-height: 40px; position: relative; cursor: pointer" flex="25" class="resource-item" layout="row"
                         layout-align="start center" ng-repeat="resource in filteredResources = (vm.poolResourcesFree | regexSearch:[{label:'name', value:'name'}]:vm.q | orderBy:'name')"
                         ng-class="{'selected-resource-item': resource.selected, 'maintenance-bg-hover': parent.vm.isResourceInMaintenance(resource), 'faulty-border': parent.vm.isResourceFaulty(resource)}"
                         ng-disabled="!$root.expertOrLO" ng-mousedown="vm.dragSelect = true; vm.dragSelectUnselect = resource.selected; vm.toggleResourceSelect(resource)"
@@ -174,5 +180,4 @@
             </div>
         </div>
     </div>
-
 </div>

--- a/app/scheduler/subarray-resources/subarray-resources.js
+++ b/app/scheduler/subarray-resources/subarray-resources.js
@@ -12,12 +12,23 @@
         vm.poolResourcesFree = ObsSchedService.poolResourcesFree;
         vm.resources_faulty = ObsSchedService.resources_faulty;
         vm.resources_in_maintenance = ObsSchedService.resources_in_maintenance;
+
+        vm.initLastKnownConfig = function () {
+            vm.lastKnownSubarrayConfig = ObsSchedService.getLastKnownSubarrayConfig(vm.subarray.id);
+        };
+
+        vm.loadLastKnownSubarrayConfig = function () {
+            ObsSchedService.loadLastKnownSubarrayConfig(vm.subarray.id);
+        };
+
         if (!$scope.$parent.vm.subarray) {
             $scope.$parent.vm.waitForSubarrayToExist().then(function (subarrayId) {
                 vm.subarray = _.findWhere(ObsSchedService.subarrays, {id: subarrayId});
+                vm.initLastKnownConfig();
             });
         } else {
             vm.subarray = $scope.$parent.vm.subarray;
+            vm.initLastKnownConfig();
         }
 
         $scope.parent = $scope.$parent;
@@ -240,14 +251,6 @@
                 $scope.$apply();
             }
         });
-
-        vm.initLastKnownConfig = function () {
-            vm.lastKnownSubarrayConfig = ObsSchedService.getLastKnownSubarrayConfig(vm.subarray.id);
-        };
-
-        vm.loadLastKnownSubarrayConfig = function () {
-            ObsSchedService.loadLastKnownSubarrayConfig(vm.subarray.id);
-        };
 
         $scope.$on('$destroy', function () {
             vm.unbindShortcuts('keydown');

--- a/app/scheduler/subarrays-draft-assignment/subarrays-draft-assignment.html
+++ b/app/scheduler/subarrays-draft-assignment/subarrays-draft-assignment.html
@@ -1,4 +1,4 @@
-<div flex layout="row" style="min-width: 1000px; min-height: 600px" ng-controller="SubArraysCtrl as vm"
+<div flex layout="row" style="min-width: 1150px; min-height: 600px" ng-controller="SubArraysCtrl as vm"
     ng-mouseup="vm.dragSelect = false">
     <div flex class="subarray-container" layout="column" style="padding-left: 8px" md-theme="{{vm.subarray.state === 'inactive'? 'grey' : vm.subarray.state === 'active'? 'green' : vm.subarray.state === 'error'? 'amber' : 'deep-purple'}}">
         <div layout="row" flex>
@@ -54,8 +54,8 @@
                         </md-menu-content>
                     </md-menu>
                     <span flex></span>
-                    <md-menu style="margin: 0 8px 0 0; padding: 0; position: relative">
-                        <span md-ink-ripple style="margin: 0; padding: 0px" ng-click="$mdMenu.open($event)" class="opaque-hover">
+                    <md-menu style="margin: 0 8px 0 0; padding: 0; position: relative" class="subarray-mode-button">
+                        <span md-ink-ripple style="margin: 0; padding: 0px" ng-click="$mdMenu.open($event)">
                             <span class="fa fa-chevron-down subarray-select-chevron" style="top: 7px"></span>
                             <span style="margin-left: 16px">MODE: <b>{{vm.subarray.mode}}</b></span> </span>
                         </span>

--- a/app/scheduler/templates/subarray-config-container.html
+++ b/app/scheduler/templates/subarray-config-container.html
@@ -1,6 +1,6 @@
 <div layout="row" layout-align="center" class="subarray-config-container">
-    <span md-ink-ripple ng-click="parent.vm.showSubarrayLogs()" class="icon-button fa fa-file-text-o" title="Show Subarray logs"
-        style="font-size: 12px; height: 14px; padding: 2px 4px; opacity: 0.5"></span>
+    <span md-ink-ripple ng-click="parent.vm.showSubarrayLogs()" class="icon-button fa fa-file-text-o opaque-hover" title="Show Subarray logs"
+        style="font-size: 18px; height: 22px; padding: 2px 4px"></span>
     <md-menu>
         <span ng-disabled="!$root.expertOrLO" title="Control Authority" ng-click="$root.expertOrLO && $mdMenu.open($event)"
             md-ink-ripple>
@@ -50,7 +50,7 @@
             </md-menu-item>
         </md-menu-content>
     </md-menu>
-    <span ng-show="vm.subarray.config_label" title="Config Label" style="margin-left: 2px">
+    <span ng-show="vm.subarray.config_label" title="Config Label" style="margin: 0 12px; cursor: default">
          <i>Config Label: </i><b>{{vm.subarray.config_label ? vm.subarray.config_label : 'None'}}</b>
      </span>
 </div>

--- a/app/services/obs-sched-service.js
+++ b/app/services/obs-sched-service.js
@@ -26,7 +26,7 @@
         api.scheduleData = [];
         api.guiUrlsRaw = [];
         api.guiUrls = {};
-
+        api.resourcesStates = {};
         api.draftArrayStates = ['DRAFT', 'DEFINED', 'APPROVED'];
 
         api.handleRequestResponse = function(request, defer) {
@@ -467,6 +467,9 @@
                         });
                     }
                 }
+            } else if (sensorName.endsWith('_state')) {
+                var component = sensorName.split('_state')[0];
+                api.resourcesStates[component] = sensor;
             } else if (sensorName.indexOf('mode_') > -1) {
                 var subarrayId = sensorName.split('_')[2];
                 var subarray = _.findWhere(api.subarrays, {


### PR DESCRIPTION
- listen to state sensors on resources
- display state of resources during activation with text and colour
- improved layout of gui-links display on subarray resources
- added load last known subarray configuration button for quick access
- increased the size and tweaked the subarray config template layout,
  also added opacity
- decreased size of resource items in subarray resources
- changed title of route Subarrays.Resource Assignment -> Subarrays.Resources
- changed title of route Subarrays.Observations Overview -> Subarrays.Overview
- adjusted min-width for subarray displays to avoid bad overlap of elements
- fix displaying of subarray config items on subarray overview
- change counter in subarray resources and observation detail to only
  count receptors assigned to subarray

Here's a flashy gif:
![apr-19-2017 15-57-24](https://cloud.githubusercontent.com/assets/8371143/25183887/1fc9baf8-2519-11e7-8117-803f247c9cd8.gif)

Here's a screenshot when they go into error state:
<img width="1440" alt="screen shot 2017-04-19 at 3 57 56 pm" src="https://cloud.githubusercontent.com/assets/8371143/25183904/2a0e82f0-2519-11e7-9be4-8c714fc5eb27.png">
