### PR TITLE
Sensor graph updates for value timestamp and misc

### DIFF
--- a/app/d3/multi-line-chart.js
+++ b/app/d3/multi-line-chart.js
@@ -821,15 +821,24 @@ angular.module('katGui.d3')
                 }
             });
 
-            scope.downloadCsv = function(useUnixTimestamps) {
+            scope.downloadCsv = function(useUnixTimestamps, includeValueTimestamp) {
                 scope.nestedData.forEach(function(sensorValues, index) {
                     var csvContent = ["timestamp,status,value"];
+                    if (includeValueTimestamp) {
+                        csvContent[0] = "value_timestamp," + csvContent[0];
+                    }
                     for (var i = 0; i < sensorValues.values.length; i++) {
                         var dataString = '';
                         var sensorInfo = sensorValues.values[i];
                         if (useUnixTimestamps) {
+                            if (includeValueTimestamp) {
+                                dataString += (sensorInfo.value_ts * 1000) + ',';
+                            }
                             dataString += (sensorInfo.sample_ts * 1000) + ',';
                         } else {
+                            if (includeValueTimestamp) {
+                                dataString += moment.utc(sensorInfo.value_ts).format('YYYY-MM-DD HH:mm:ss.SSS') + ',';
+                            }
                             dataString += moment.utc(sensorInfo.sample_ts).format('YYYY-MM-DD HH:mm:ss.SSS') + ',';
                         }
                         dataString += sensorValues.values[i].status + ',';

--- a/app/sensor-graph/sensor-graph.html
+++ b/app/sensor-graph/sensor-graph.html
@@ -166,6 +166,12 @@
                 </md-button>
                 <md-menu-content width="4" style="padding-left: 16px;" id="sensor-graph-menu-content" md-menu-disable-close>
                     <md-menu-item>
+                        <md-checkbox class="md-primary" ng-model="vm.plotUsingValueTimestamp" ng-change="vm.plotUsingValueTimestampChanged()"
+                            title="Clear and redraw the chart using value timestamps instead of sample timestamps">
+                            Plot Using Value Timestamps
+                        </md-checkbox>
+                    </md-menu-item>
+                    <md-menu-item>
                         <md-checkbox class="md-primary" ng-model="vm.showGridLines" ng-change="vm.showOptionsChanged()">
                             Show Grid Lines
                         </md-checkbox>

--- a/app/sensor-graph/sensor-graph.html
+++ b/app/sensor-graph/sensor-graph.html
@@ -109,10 +109,16 @@
                 </md-button>
                 <div class="menu-item-divider" style="width: 100%"></div>
                 <div layout="row" layout-align="start center" style="min-height: 48px">
-                    <md-checkbox class="md-primary" ng-model="vm.useUnixTimestamps" ng-init="vm.useUnixTimestamps = false"
-                        ng-disabled="vm.sensorNames.length === 0" style="margin: 4px;; padding: 0">
-                        Use Unix timestamps
-                    </md-checkbox>
+                    <div layout="column">
+                        <md-checkbox class="md-primary" ng-model="vm.useUnixTimestamps" ng-change="vm.useUnixTimestampsChanged()"
+                            ng-disabled="vm.sensorNames.length === 0" style="margin: 4px; padding: 0">
+                            Use Unix timestamps
+                        </md-checkbox>
+                        <md-checkbox class="md-primary" ng-model="vm.includeValueTimestamp" ng-change="vm.includeValueTimestampChanged()"
+                            ng-disabled="vm.sensorNames.length === 0" style="margin: 4px; padding: 0">
+                            Include Value timestamps
+                        </md-checkbox>
+                    </div>
                     <md-button ng-disabled="vm.sensorNames.length === 0" class="md-primary md-raised" ng-click="vm.downloadCSV()">
                         Download As CSV
                     </md-button>
@@ -148,6 +154,9 @@
             clear-function="vm.clearChart" remove-sensor-function="vm.removeSensorLine" download-csv="vm.downloadAsCSV"
             y-max="vm.yAxisMaxValue" y-min="vm.yAxisMinValue" mouse-over-tooltip="true"></multi-line-chart>
         <div layout="row" class="floating-chart-actions">
+            <md-button class="md-icon-button" ng-click="vm.reloadAllData()" title="Reload All Sensor Data">
+                <md-icon class="fa" md-font-icon="fa-refresh"></md-icon>
+            </md-button>
             <md-button class="md-icon-button" ng-click="vm.clearData()" title="Clear Data">
                 <md-icon class="fa" md-font-icon="fa-remove"></md-icon>
             </md-button>

--- a/app/sensor-graph/sensor-graph.js
+++ b/app/sensor-graph/sensor-graph.js
@@ -34,6 +34,7 @@
             $localStorage['sensorGraphAutoCompleteList'] = [];
         }
 
+        vm.plotUsingValueTimestamp = $localStorage['plotUsingValueTimestamp']? true: false;
         vm.includeValueTimestamp = $localStorage['includeValueTimestamp']? true: false;
         vm.useUnixTimestamps = $localStorage['useUnixTimestamps']? true: false;
 
@@ -43,6 +44,12 @@
 
         vm.useUnixTimestampsChanged = function () {
             $localStorage['useUnixTimestamps'] = vm.useUnixTimestamps;
+        };
+
+        vm.plotUsingValueTimestampChanged = function () {
+            $localStorage['plotUsingValueTimestamp'] = vm.plotUsingValueTimestamp;
+            vm.showOptionsChanged();
+            vm.reloadAllData();
         };
 
         //TODO add an option to append to current data instead of deleting existing
@@ -132,6 +139,7 @@
                 $scope.$apply();
             }
             vm.loadOptions({
+                plotUsingValueTimestamp: vm.plotUsingValueTimestamp,
                 showGridLines: vm.showGridLines,
                 hideContextZoom: !vm.showContextZoom,
                 useFixedYAxis: vm.useFixedYAxis,
@@ -356,6 +364,7 @@
             vm.sensorSearchNames = [];
             vm.findSensorNames(vm.searchText); //simulate keypress
             vm.loadOptions({
+                plotUsingValueTimestamp: vm.plotUsingValueTimestamp,
                 showGridLines: vm.showGridLines,
                 hideContextZoom: !vm.showContextZoom,
                 useFixedYAxis: vm.useFixedYAxis,

--- a/app/sensor-graph/sensor-graph.js
+++ b/app/sensor-graph/sensor-graph.js
@@ -28,10 +28,22 @@
         vm.yAxisMinValue = 0;
         vm.yAxisMaxValue = 100;
         vm.connectInterval = null;
+
         vm.sensorServiceConnected = SensorsService.connected;
         if (!$localStorage['sensorGraphAutoCompleteList']) {
             $localStorage['sensorGraphAutoCompleteList'] = [];
         }
+
+        vm.includeValueTimestamp = $localStorage['includeValueTimestamp']? true: false;
+        vm.useUnixTimestamps = $localStorage['useUnixTimestamps']? true: false;
+
+        vm.includeValueTimestampChanged = function () {
+            $localStorage['includeValueTimestamp'] = vm.includeValueTimestamp;
+        };
+
+        vm.useUnixTimestampsChanged = function () {
+            $localStorage['useUnixTimestamps'] = vm.useUnixTimestamps;
+        };
 
         //TODO add an option to append to current data instead of deleting existing
 
@@ -185,6 +197,15 @@
                 vm.sensorSearchFieldLengthError = true;
                 vm.sensorSearchFieldShowTooltip = true;
             }
+        };
+
+        vm.reloadAllData = function() {
+            vm.sensorNames.forEach(function (sensor) {
+                // stagger the katstore-webserver calls
+                $timeout(function () {
+                    vm.findSensorData(sensor);
+                }, 500);
+            });
         };
 
         vm.findSensorNames = function (searchStr, event) {
@@ -463,7 +484,7 @@
 
         vm.downloadCSV = function () {
             //bound in multiLineChart
-            vm.downloadAsCSV(vm.useUnixTimestamps);
+            vm.downloadAsCSV(vm.useUnixTimestamps, vm.includeValueTimestamp);
         };
 
         $timeout(function () {


### PR DESCRIPTION
- added a checkbox to include value timestamp when downloading as csv
- use localstorage to remember include value timestamp and use unix
  timestamp checkbox values and plot sensor-graph using value timestamps across page loads
- added a refresh all button on sensor graph that will reload all the
  sensors in a staggered (but still in parallel) manner, next to the
  clear graph button on the top right
- added checkbox to plot sensor-graph using value timestamps

This PR addresses https://skaafrica.atlassian.net/browse/CB-1932, https://skaafrica.atlassian.net/browse/CB-1621 and half of https://skaafrica.atlassian.net/browse/CB-1931.