### PR TITLE
Reload gui without cache better and reuse an existing visible toast message

### DIFF
--- a/app/services/config-service.js
+++ b/app/services/config-service.js
@@ -206,6 +206,7 @@
                     var cachedBuildDate = new Date(document.katguiBuildDate);
                     var latestBuildDate = new Date(parseInt(result.data.buildDate));
                     if (cachedBuildDate < latestBuildDate) {
+
                         var textContent = '<b>You have loaded an older version of KATGUI than what is currently available!</b></br>' +
                                      '</br>Your version was built on ' + cachedBuildDate + ', but the latest version was built on ' + latestBuildDate +
                                      '</br></br>Click "Reload" to get the latest version.</p>';
@@ -217,7 +218,7 @@
                                     $scope.title = 'KATGUI is out of date!';
                                     $scope.content = $sce.trustAsHtml(textContent);
                                     $scope.resolve = function () {
-                                        window.location.reload(true);
+                                        location.reload(true);
                                     };
                                     $scope.reject = function () {
                                         $mdDialog.hide();

--- a/app/services/config-service.js
+++ b/app/services/config-service.js
@@ -206,7 +206,6 @@
                     var cachedBuildDate = new Date(document.katguiBuildDate);
                     var latestBuildDate = new Date(parseInt(result.data.buildDate));
                     if (cachedBuildDate < latestBuildDate) {
-
                         var textContent = '<b>You have loaded an older version of KATGUI than what is currently available!</b></br>' +
                                      '</br>Your version was built on ' + cachedBuildDate + ', but the latest version was built on ' + latestBuildDate +
                                      '</br></br>Click "Reload" to get the latest version.</p>';

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,7 +44,7 @@ gulp.task('clean-tests', function () {
 });
 
 gulp.task('clean:csstmp', ['css:material', 'css:main', 'css:concat', 'clean'], function (cb) {
-    return del(['dist/main.app.full.*', 'dist/angular-material.min.css']);
+    return del(['dist/main.app.full.min.css', 'dist/angular-material.min.css']);
 });
 
 gulp.task('css:material', ['clean'], function () {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,7 +44,7 @@ gulp.task('clean-tests', function () {
 });
 
 gulp.task('clean:csstmp', ['css:material', 'css:main', 'css:concat', 'clean'], function (cb) {
-    return del(['dist/main.app.full.min.css', 'dist/angular-material.min.css']);
+    return del(['dist/main.app.full.*', 'dist/angular-material.min.css']);
 });
 
 gulp.task('css:material', ['clean'], function () {
@@ -71,7 +71,7 @@ gulp.task('css:main', ['clean'], function () {
 
 gulp.task('css:concat', ['css:main', 'css:material', 'clean'], function () {
     return gulp.src(['dist/angular-material.min.css', 'dist/main.app.full.min.css'])
-        .pipe(concat('app.full.min.css'))
+        .pipe(concat('app.full.min.' + buildDate + '.css'))
         .pipe(gulp.dest('dist/'));
 });
 
@@ -93,7 +93,7 @@ gulp.task('js', ['clean'], function () {
     combined.queue(templateStream);
 
     return combined.done()
-        .pipe(concat('app.full.min.js'))
+        .pipe(concat('app.full.min.' + buildDate + '.js'))
         .pipe(insert.append('document.katguiBuildDate = ' + buildDate))
         .pipe(ngannotate())
         .pipe(uglify())
@@ -105,9 +105,9 @@ gulp.task('indexHtml', ['clean'], function () {
         .pipe(gCheerio(function ($) {
             $('script[data-remove!="exclude"]').remove();
             $('link').remove();
-            $('body').append('<script src="app.full.min.js"></script>');
+            $('body').append('<script src="app.full.min.' + buildDate + '.js"></script>');
             $('head').append('<link rel="icon" type="image/png" href="images/favicon.ico" sizes="32x32">');
-            $('head').append('<link rel="stylesheet" href="app.full.min.css">');
+            $('head').append('<link rel="stylesheet" href="app.full.min.' + buildDate + '.css">');
         }))
         .pipe(htmlmin(htmlminOptions))
         .pipe(gulp.dest('dist/'));


### PR DESCRIPTION
- Added the build date to the minified files to solve the caching problem when updating the static files of the gui on the portal node
- Reuse an already visible toast element and update its text when multiple toasts are displayed instead of creating a new one for every message