### PR TITLE
Allow &amp characters in userlogs query params, we rewrite the url with proper '&' chars and other fixes

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -430,6 +430,7 @@
         $urlRouterProvider.otherwise('/home');
         $mdAriaProvider.disableWarnings();
         $locationProvider.html5Mode(true);
+
         configureThemes($mdThemingProvider);
 
         $stateProvider.state('login', {
@@ -662,7 +663,7 @@
             templateUrl: 'app/weather/weather.html',
             title: 'Weather'
         });
-        $stateProvider.state('userlogs', {
+        var userlogsState = {
             url: '/userlogs?action&id&startTime&endTime&tags&content',
             templateUrl: 'app/userlogs/userlogs.html',
             title: 'User Logging',
@@ -688,7 +689,18 @@
                     squash: true
                 }
             }
+        };
+        $urlRouterProvider.when(userlogsState.url, function ($location, $state, $match) {
+            var locationUrl = $location.url();
+            if (locationUrl.indexOf('&amp;') > -1) {
+                locationUrl = locationUrl.replace(/&amp;/g, '&');
+                var queryParams = $location.url(locationUrl).search();
+                $state.transitionTo('userlogs', queryParams);
+            } else {
+                $state.transitionTo('userlogs', $match);
+            }
         });
+        $stateProvider.state('userlogs', userlogsState);
         $stateProvider.state('userlog-tags', {
             url: '/userlog-tags',
             templateUrl: 'app/userlogs/userlog-tags.html',

--- a/app/process-control/process-control.js
+++ b/app/process-control/process-control.js
@@ -80,7 +80,7 @@
         };
 
         vm.listResourceSensors = function (resources) {
-            var resultPromise = $q.defer();
+            var resultDefer = $q.defer();
             var listResourcesPromises = [];
 
             for (var i in resources) {
@@ -127,9 +127,9 @@
                         }
                     }, 1000);
                 }
-                resultPromise.resolve();
+                resultDefer.resolve();
             });
-            return resultPromise;
+            return resultDefer.promise;
         };
 
         vm.stopProcess = function (nm, resource) {

--- a/app/services/userlog-service.js
+++ b/app/services/userlog-service.js
@@ -368,8 +368,8 @@
                         $scope.editMode = editMode;
                         $scope.log = log;
                         $scope.tags = api.tags;
-                        $scope.start_time = log.start_time;
-                        $scope.end_time = log.end_time;
+                        $scope.start_time = log.start_time? log.start_time: '';
+                        $scope.end_time = log.end_time? log.end_time: '';
                         $scope.content = log.content;
                         $scope.selectedTags = [];
                         $scope.attachments = log.attachments;
@@ -377,8 +377,8 @@
                         $scope.validTags = true;
                         $scope.mandatoryTagsListString = api.mandatoryTagsListString;
                         $scope.showInvalidTagsTooltip = false;
-                        $scope.openedWithoutStartTime = log.start_time !== null && log.start_time.length > 0;
-                        $scope.openedWithoutEndTime = log.end_time !== null && log.end_time.length > 0;
+                        $scope.openedWithoutStartTime = $scope.start_time !== null && $scope.start_time.length > 0;
+                        $scope.openedWithoutEndTime = $scope.end_time !== null && $scope.end_time.length > 0;
                         $scope.chipHasBeenAdded = false;
                         $scope.focusTarget = focusTarget? focusTarget: 'userlogDialogStartTimeElement';
 

--- a/app/userlogs/userlogdialog.tmpl.html
+++ b/app/userlogs/userlogdialog.tmpl.html
@@ -1,7 +1,7 @@
 <md-dialog md-theme="{{$root.themePrimary}}" class="md-whiteframe-z1" style="min-width: 800px; min-height: 626px; overflow: visible"
            ng-click="showEndDatePicker = false; showDatePicker = false; toggleTags = false;">
     <md-toolbar class="md-toolbar-tools md-whiteframe-z1">
-        <span>{{editMode? 'User Log Editor (' + log.id + ')': 'User Log Viewer (' + log.id + ')'}}</span>
+        <span>{{editMode && log.id? 'User Log Editor (' + log.id + ')': editMode? 'New User Log': 'User Log Viewer (' + log.id + ')'}}</span>
     </md-toolbar>
     <md-dialog-content style="padding: 12px; min-height: 510px" md-theme="{{$root.themePrimaryButtons}}" layout="column">
         <div layout="row">

--- a/app/userlogs/userlogs.js
+++ b/app/userlogs/userlogs.js
@@ -19,7 +19,7 @@
         .controller('UserlogCtrl', UserlogCtrl);
 
     function UserlogCtrl(MonitorService, $localStorage, $interval, $mdDialog, $scope, $rootScope, $stateParams,
-                         $filter, $log, $timeout, UserLogService, MOMENT_DATETIME_FORMAT, DATETIME_FORMAT) {
+                         $filter, $log, $timeout, $state, UserLogService, MOMENT_DATETIME_FORMAT, DATETIME_FORMAT) {
 
         var vm = this;
         UserLogService.userlogs = [];
@@ -215,7 +215,11 @@
         };
 
         vm.editUserLog = function (userlog, event) {
-            UserLogService.editUserLog(userlog, $rootScope.currentUser.id === userlog.user_id, 'userlogDialogContentElement', event);
+            UserLogService.editUserLog(
+                userlog, $rootScope.currentUser.id === userlog.user_id, 'userlogDialogContentElement', event)
+                .then(function() {
+                    $state.transitionTo('userlogs', null, { notify: false, reload: false });
+                });
         };
 
         vm.afterInit = function() {


### PR DESCRIPTION
Also: when editing a userlog, set the start and end times to empty strings
when they are null or undefined. Fixed title of userlog dialog to not
show empty parentheses when creating a new userlog. Fixed returning of
(unused) promise (was returning defer object) on process control
display.