### PR TITLE
Naively try to remove duplicates from sensor values before downloading them as csv

### DIFF
--- a/app/d3/multi-line-chart.js
+++ b/app/d3/multi-line-chart.js
@@ -852,6 +852,14 @@ angular.module('katGui.d3')
 
             scope.downloadCsv = function(useUnixTimestamps, includeValueTimestamp) {
                 scope.nestedData.forEach(function(sensorValues, index) {
+                    var lengthBeforeUnique = sensorValues.values.length;
+                    sensorValues.values = _.uniq(sensorValues.values, function (item) {
+                        return item[timestampKey];
+                    });
+                    var lengthAfterUnique = sensorValues.values.length;
+                    if (lengthBeforeUnique > lengthAfterUnique) {
+                        $log.warn('Duplicate sensor values found, trimmed ' + (lengthBeforeUnique - lengthAfterUnique) + ' samples for ' + sensorValues.key);
+                    }
                     var csvContent = ["timestamp,status,value"];
                     if (includeValueTimestamp) {
                         csvContent[0] = "value_timestamp," + csvContent[0];


### PR DESCRIPTION
This is to ensure that the downloaded csv files do not have duplicates. When we rework the katstore webserver and gui to work with the rados + nats implementation, we will fix the duplicate values that can sometimes be in sensor-graph. Duplicate values cannot be seen on the graph.