### PR TITLE
fix tooltip by adding a prefix(component) before the sensor name

### DIFF
--- a/app/d3/d3-util-service.js
+++ b/app/d3/d3-util-service.js
@@ -105,10 +105,7 @@ angular.module('katGui.d3')
             var sensorValue;
             var pythonIdentifier = d.sensor.replace(/\./g, '_');
             var prefix = d.prefix? d.prefix : '';
-            //var fullSensorName = prefix + (rootName? rootName + '_' : '') + d.sensor;
-            var fullSensorName = d.sensor?
-                prefix + (d.component && d.component !== 'all'? d.component + '_' : '') + d.sensor :
-                prefix + rootName;
+            var fullSensorName = prefix + (rootName? rootName + '_' : '') + d.sensor;
             if (d.sensor && StatusService.sensorValues[pythonIdentifier]) {
                 sensorValue = StatusService.sensorValues[pythonIdentifier];
             }


### PR DESCRIPTION
@lvdheever Please review

This PR fix the tool tip for receptor health and config health.
To get the sensor value the component must be part of the sensor name, e.g the sensor name must be m011_rsc_rsc_he_compressor_state not rsc_rsc_he_compressor_state.

Before
<img width="338" alt="Before" src="https://user-images.githubusercontent.com/6682664/40727436-2d53398e-6428-11e8-8abf-90b67a1ce07e.png">

After
<img width="370" alt="After" src="https://user-images.githubusercontent.com/6682664/40727430-2abeb9f0-6428-11e8-9a3c-32f6c2e9e927.png">


[Jira](https://skaafrica.atlassian.net/browse/CB-3012) 