### PR TITLE
Height adjustment of textboxes

### DIFF
--- a/app/userlogs/userlogdialog.tmpl.html
+++ b/app/userlogs/userlogdialog.tmpl.html
@@ -48,16 +48,16 @@
             </div>
         </div>
         <div class="md-whiteframe-z1" style="margin: 8px 0" flex>
-            <md-input-container id="userlogDialogContentElement" md-is-error="content.length === 0" style="margin: 16px 0; min-height: 190px; max-height: 190px" class="md-block" flex>
+            <md-input-container id="userlogDialogContentElement" md-is-error="content.length === 0" style="margin: 16px 0; min-height: 150px; max-height: 150px" class="md-block" flex>
                 <label>Log Content</label>
-                <textarea style="overflow-y: scroll; resize: none; width: 100%; min-height: 280px; max-height: 280px; height: 280px" ng-disabled="!editMode" md-select-on-focus rows="10" md-maxlength="10000" ng-model="content"></textarea>
+                <textarea style="overflow-y: overlay; resize: none; width: 100%; min-height: 150px; max-height: 150px; height: 150px" ng-disabled="!editMode" md-select-on-focus rows="10" md-maxlength="10000" ng-model="content"></textarea>
             </md-input-container>
         </div>
 
         <div class="md-whiteframe-z1" style="margin: 8px 0" flex>
-            <md-input-container style="margin: 24px 0; min-height: 80px; max-height: 80px" class="md-block" flex>
+            <md-input-container style="margin: 24px 0; min-height: 50px; max-height: 50px" class="md-block" flex>
                 <label>Compound Tags</label>
-                <textarea style="overflow-y: scroll; resize: none; min-height: 80px; max-height: 50px; height: 50px" ng-disabled="editMode" ng-list="&#10;" ng-trim="false" md-select-on-focus rows="2" md-maxlength="1000" ng-model="compound_tags"></textarea>
+                <textarea style="overflow-y: scroll; resize: none; min-height: 50px; max-height: 50px; height: 50px" ng-disabled="editMode" ng-list="&#10;" ng-trim="false" md-select-on-focus rows="2" md-maxlength="1000" ng-model="compound_tags"></textarea>
             </md-input-container>
         </div>
 


### PR DESCRIPTION
Adjusting the height of both the log content and compound tag text boxes to accommodate for the scrollbar overflow.

@ofaletse please review