### PR TITLE
Fixing compound tags on sensor-list

### DIFF
--- a/app/sensor-list/sensor-list.js
+++ b/app/sensor-list/sensor-list.js
@@ -94,10 +94,23 @@
               " Time: " + sensor.received_timestamp +
               "\nValue: " + sensor.value
               startTime = sensor.timestamp
-              compoundTag = $rootScope.deriveCompoundTag(sensor.original_name)
-              if (compoundTag) {
+              if (sensor.original_name){
+                compoundTag = $rootScope.deriveCompoundTag(sensor.original_name)
+                if (compoundTag) {
                   compoundTags.push(compoundTag)
-              }
+                }
+              } else {
+                  _device_name = sensor.shortName.split(/_(.+)/)[0]
+                  _sensor = sensor.shortName.split(/_(.+)/)[1]
+                  if (_device_name && _sensor) {
+                    sensor.shortName = _device_name.concat('.', _sensor)
+                  }
+                  original_name = sensor.component.concat('.', sensor.shortName)
+                  compoundTag = $rootScope.deriveCompoundTag(original_name)
+                  if (compoundTag) {
+                    compoundTags.push(compoundTag)
+                  }
+                }
           }
           var tag = _.findWhere(
               UserLogService.tags,

--- a/app/sensor-list/sensor-list.js
+++ b/app/sensor-list/sensor-list.js
@@ -94,16 +94,16 @@
               " Time: " + sensor.received_timestamp +
               "\nValue: " + sensor.value
               startTime = sensor.timestamp
-              if (sensor.original_name){
+              if (sensor.original_name) {
                 compoundTag = $rootScope.deriveCompoundTag(sensor.original_name)
                 if (compoundTag) {
                   compoundTags.push(compoundTag)
                 }
-              } else {
-                  _device_name = sensor.shortName.split(/_(.+)/)[0]
-                  _sensor = sensor.shortName.split(/_(.+)/)[1]
-                  if (_device_name && _sensor) {
-                    sensor.shortName = _device_name.concat('.', _sensor)
+              } else  {
+                  deviceName = sensor.shortName.split(/_(.+)/)[0]
+                  sensorName = sensor.shortName.split(/_(.+)/)[1]
+                  if (deviceName && sensorName) {
+                    sensor.shortName = deviceName.concat('.', sensorName)
                   }
                   original_name = sensor.component.concat('.', sensor.shortName)
                   compoundTag = $rootScope.deriveCompoundTag(original_name)


### PR DESCRIPTION
Handling a case where sensors are divided with underscores, for formulation of compound tags on sensor-list page, where compound tags were not populating for sensors divided with underscores only.

Dist. files will be added once PR has been approved. Please find below screen-shots of the derived 

Jira: MT-295

![screenshot 2018-11-23 at 15 58 37](https://user-images.githubusercontent.com/10397948/48947154-e7be1000-ef38-11e8-888f-6c0634226c02.png)

![screenshot 2018-11-23 at 15 59 08](https://user-images.githubusercontent.com/10397948/48947139-d543d680-ef38-11e8-8575-a7dfbd7b8142.png)
 

