### PR TITLE
Fix broken gulp build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,6 +60,7 @@ gulp.task('css:main', ['clean'], function () {
         .pipe(insert.prepend('@fa-font-path: "fonts";'))
         .pipe(less().on('error', function(e){
 	    console.log(e);
+	    throw e;
 	}))
         .pipe(cssmin({
             keepSpecialComments: false,
@@ -101,6 +102,7 @@ gulp.task('js', ['clean'], function () {
         .pipe(ngannotate())
         .pipe(uglify().on("error", function(e){
 	    console.log(e);
+	    throw e;
 	 }))
         .pipe(gulp.dest('dist/'));
 });


### PR DESCRIPTION
The previous change to gulp file printed out the full error message to assist with dev build. However, it did not throw the exception resulting in failed build not picked by jenkins. The error is now printed and re-thrown.