### PR TITLE
Throttle set to 10s

### DIFF
--- a/app/services/obs-sched-service.js
+++ b/app/services/obs-sched-service.js
@@ -371,7 +371,7 @@
             });
         };
 
-        api.throttleGetProgramBlocksObservationSchedule = _.throttle(api.getProgramBlocksObservationSchedule, 300);
+        api.throttleGetProgramBlocksObservationSchedule = _.throttle(api.getProgramBlocksObservationSchedule, 10000);
 
         api.getCompletedScheduleBlocks = function(sub_nr, max_nr) {
             //TODO smoothly combine the existing list with the new list so that there isnt a screen flicker


### PR DESCRIPTION
This is to make katgui send fewer update requests when SBs are starting.
Main change is in `app/services/obs-sched-service.js`.
Previous PR mysteriously closed, opening another with just the applicable
file changed. Requests are now 10s apart instead of 300ms.

JIRA: [MT-356](https://skaafrica.atlassian.net/browse/MT-356)