### PR TITLE
link the scheduler display with the sensor group display

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -766,7 +766,14 @@
         $stateProvider.state('sensor-groups', {
             url: '/sensor-groups',
             templateUrl: 'app/sensor-groups/sensor-groups.html',
-            title: 'Sensor Groups'
+            title: 'Sensor Groups',
+            //makes the params optional
+            params: {
+                band: {
+                    value: null,
+                    squash: true
+                }
+            }
         });
         $stateProvider.state('about', {
             url: '/about',

--- a/app/scheduler/scheduler-home.js
+++ b/app/scheduler/scheduler-home.js
@@ -410,6 +410,24 @@
                 });
         };
 
+        vm.navigateToSensorSensorGroup = function() {
+            /* Go to the sensor group page, Note that the band parameter will be used to
+            note that a call was from scheduler display page */
+            if (vm.subarray.band) {
+                try {
+                    $state.go('sensor-groups',
+                    {
+                        band: vm.subarray.band
+                    });
+                }
+                catch (error) {
+                    NotifyService.showSimpleDialog('Error',
+                      'Unexpected error occurred (' + error
+                +')');
+                }
+            }
+        };
+
         vm.openCADialog = function(event) {
             $mdDialog
                 .show({

--- a/app/sensor-groups/sensor-groups.js
+++ b/app/sensor-groups/sensor-groups.js
@@ -4,7 +4,7 @@
         .controller('SensorGroupsCtrl', SensorGroupsCtrl);
 
     function SensorGroupsCtrl($scope, $rootScope, MonitorService, $timeout, $interval, NotifyService,
-                              ConfigService, $log, MOMENT_DATETIME_FORMAT, KatGuiUtil) {
+                              $stateParams, ConfigService, $log, MOMENT_DATETIME_FORMAT, KatGuiUtil) {
 
         var vm = this;
         vm.sensorGroups = {};
@@ -14,10 +14,14 @@
         vm.sensorValues = {};
         vm.hideNominalSensors = false;
         vm.sensorsRegex = '';
+        vm.band = $stateParams.band
 
         ConfigService.loadSensorGroups().then(function (result) {
             vm.sensorGroupList = Object.keys(result);
             vm.sensorGroups = result;
+            /* We need to wait for the results first, before we automatically select
+            the group, otherwise we will select from nothing.*/
+            vm.selectSensorGroup();
         });
 
         vm.sensorsOrderByFields = [
@@ -63,10 +67,22 @@
             vm.subscribedSensors.forEach(function (sensor) {
                 MonitorService.unsubscribeSensor(sensor);
             });
+
             vm.subscribedSensors = [];
             vm.sensorValues = {};
             vm.sensorsGroupBeingDisplayed = sensorGroupName;
             vm.initSensors();
+        };
+
+        vm.selectSensorGroup = function() {
+            /* Select the 'Dig BAND(l, x, s, u) Sync remaining' sensor group
+            the only time the band will not be empty is when we are routing
+            from the scheduler display. */
+
+            if(vm.band && vm.band != '') {
+               var sensorGroupName = 'Dig ' + vm.band + ' Sync remaining'
+               vm.setSensorGroupStrategy(sensorGroupName)
+            }
         };
 
         vm.displaySensorValue = function ($event, sensor) {


### PR DESCRIPTION
@xinyuwu Kindly please review when you get a moment.

In this PR I added functionality that allow the user to click a button/label from scheduler display and be re-directed/routed to the sensor-group display and automatically select the sensor group of the selected band in the subarray for the digitiser global sync time remaining e.g `Dig l Sync remaining` or  `Dig u Sync remaining` . 

It is worth noting that `vm.navigateToSensorSensorGroup` is not yet called in `scheduler-home.html` as I am still waiting for [PR 524](https://github.com/ska-sa/katgui/pull/524) to be merged. 
Also due to cooling issues that forced us to shutdown servers, I could not create the screenshot, however I am confident and sure that all is working as expected.

I opt not to create the dist files, the dist files will be created in [PR 524](https://github.com/ska-sa/katgui/pull/524) 

JIRA: [MT-1122](https://skaafrica.atlassian.net/browse/MT-1122)
