### PR TITLE
Pinned nodejs version expectation to 10.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "engines": {
-        "node": "~10.19"
+        "node": "~10"
     },
     "name": "katGui",
     "version": "1.0.1",


### PR DESCRIPTION
This PR removes the pinning of minor versions on nodejs and only pins it to v10-major. This is due to a couple of failed builds which resulted on up'ing the minor version:
- [karoocamv26 build](http://ci.camlab.kat.ac.za/view/3.%20Multibranch%20Master/job/katgui-multibranch/job/release%252Fkaroocamv26/4/console)
- https://github.com/ska-sa/katgui/commit/b98a75b8e4dcd35e5672c721cc72d1b37a803212 : Cannot locate Jenkins build
- https://github.com/ska-sa/katgui/commit/4b887826c5b4129aabc77422c626e4b9f03b157d
- https://github.com/ska-sa/katgui/commit/01516840749f76aaee3ef2d0bfbff66659a0f0c2