### PR TITLE
Fix Sensor List page scrolling

### DIFF
--- a/app/sensor-list/sensor-list.html
+++ b/app/sensor-list/sensor-list.html
@@ -1,10 +1,10 @@
 
-<div layout="column" flex ng-controller="SensorListCtrl as vm" style="min-height: 640px; min-width: 1000px" ng-keypress="setFilterOnEnter($event, searchText)">
+<div layout="column" flex ng-controller="SensorListCtrl as vm" style="min-height: 825px; min-width: 1000px" ng-keypress="setFilterOnEnter($event, searchText)">
     <div flex layout="row" style="margin: 8px">
         <div layout="column" style="width: 220px">
             <div layout="column" ng-repeat="node in vm.nodes | orderBy:node:true track by $index" class="md-whiteframe-z1"
-                style="margin-bottom: 8px;" ng-class="{'at-least-400-high': node === 'Proxies'}">
-                <md-toolbar class="md-whiteframe-z1 md-toolbar-tools-medium" layout="row" layout-align="center center">
+                style="margin-bottom: 8px;" ng-class="{'at-least-400-high': node === 'Components' || 'Proxies'}">
+                <md-toolbar class="md-whiteframe-z1 md-toolbar-tools-medium" layout="row" layout-align="none center">
                     <span>{{node}}</span>
                 </md-toolbar>
                 <div style="overflow: auto" layout-wrap layout="row" layout-align="start">


### PR DESCRIPTION
This fixes the scrolling of the Sensor page, by making "Components" frame scrollable and also increasing the height of the Sensor List frame.

*Screenshots below:*

**Sensor list page - on a minimized screen size**
<img width="728" alt="Screenshot 2020-05-15 at 12 36 37" src="https://user-images.githubusercontent.com/10397948/82042568-61583980-96aa-11ea-993a-dd56cb191071.png">

**Sensor list page - full screen**
<img width="1680" alt="Screenshot 2020-05-15 at 12 36 55" src="https://user-images.githubusercontent.com/10397948/82042472-34a42200-96aa-11ea-8887-c2ff56c69392.png">


JIRA: [MT-1482](https://skaafrica.atlassian.net/browse/MT-1482)
