### PR TITLE
Fixing the narrow centre frequency display

### DIFF
--- a/app/scheduler/scheduler.less
+++ b/app/scheduler/scheduler.less
@@ -757,8 +757,8 @@
 
 .narrow-freq-input-box {
     font-weight: bold;
-    width: 60px;
-    max-width: 60px;
+    width: 90px;
+    max-width: 90px;
     background: transparent;
     border-bottom: 0px solid black;
     border-top: 0;

--- a/app/scheduler/templates/subarray-config-container.html
+++ b/app/scheduler/templates/subarray-config-container.html
@@ -86,7 +86,8 @@
         ng-class="{'invalid-narrow-freq': !parent.vm.isNarrowBandFreqValid(1)}"
         class="fade-in narrow-freq-input-box ng-pristine ng-untouched ng-empty"
         ng-disabled="!$root.expertOrLO"
-        ng-model="vm.subarray.requested_narrow1_centre_frequency">
+        ng-model="vm.subarray.requested_narrow1_centre_frequency"
+        type="number">
     </div>
 
     <md-menu>

--- a/app/scheduler/templates/subarray-config-container.html
+++ b/app/scheduler/templates/subarray-config-container.html
@@ -86,8 +86,7 @@
         ng-class="{'invalid-narrow-freq': !parent.vm.isNarrowBandFreqValid(1)}"
         class="fade-in narrow-freq-input-box ng-pristine ng-untouched ng-empty"
         ng-disabled="!$root.expertOrLO"
-        ng-model="vm.subarray.requested_narrow1_centre_frequency"
-        type="number">
+        ng-model="vm.subarray.requested_narrow1_centre_frequency">
     </div>
 
     <md-menu>


### PR DESCRIPTION
This is a quick fix to the narrow band centre frequency display, on the subarray page. 

*Screenshots or code snippets (if appropriate):*

_**A full screen showing the whole number in the narrow centre frequency**_
<img width="1644" alt="Screenshot 2020-08-24 at 09 52 47" src="https://user-images.githubusercontent.com/10397948/91018444-e3cc8f80-e5ef-11ea-98ba-f85fb208e6bc.png">

_**A minimized screen showing the whole number in the narrow centre frequency**_
<img width="643" alt="Screenshot 2020-08-24 at 09 53 02" src="https://user-images.githubusercontent.com/10397948/91018469-ec24ca80-e5ef-11ea-9a64-39c469a257f0.png">


