### PR TITLE
Hotfix V27: Fix rainfall display on Gui

### DIFF
--- a/app/weather/weather.js
+++ b/app/weather/weather.js
@@ -11,7 +11,7 @@
             'air_pressure',
             'air_temperature',
             'air_relative_humidity',
-            'weather_rainfall',
+            'weather_rain',
             'gust_wind_speed',
             'wind_direction',
             'mean_wind_speed'


### PR DESCRIPTION
On the MKAT Karoo system, the GUI's weather display shows a sensor `weather_rainfall`, but there is no value.  On MKAT dev systems the sensor has a value.  We need the value to show for MKAT Karoo.

JIRA: [MT-1671](https://skaafrica.atlassian.net/browse/MT-1671)
see https://github.com/ska-sa/katgui/pull/570