### PR TITLE
Updated node version on the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Ensure that `gulp` is in your path. e.g.`~/.yarn/bin/gulp`
 You could be lucky by trying the following:
 ```bash
 sudo apt-get install curl
-curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 


### PR DESCRIPTION
- Updated node version on the README file to match that of the `package.json` and node 8 is deprecated. 

![image](https://user-images.githubusercontent.com/7910856/95323402-63f83d00-089e-11eb-9f00-7c66a103b964.png)
